### PR TITLE
Add static IBC escrow web explorer

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,42 @@
+name: Deploy Web App
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: corepack enable
+      - run: yarn install --frozen-lockfile --non-interactive
+      - run: yarn build:web
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: web
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ logs/
 data/
 node_modules/
 dist/
+web/assets/
 .env
 *.log
 *.txt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IBC Escrow Audit Tool
 
-TypeScript CLI tool for auditing IBC token escrow accounts between Cosmos chains. Verifies token balances and performs recursive IBC denomination tracing to origin chains.
+TypeScript CLI and static web app for auditing and looking up IBC token escrow accounts between Cosmos chains. The CLI uses gRPC-first audits with REST fallback; the web app performs live escrow and channel lookups through Lazy-LB-compatible universal REST paths or direct `rest.cosmos.directory` requests.
 
 ## Requirements
 
@@ -39,6 +39,17 @@ Edit `config.json`:
 ```
 
 ## Usage
+
+### Web App
+```bash
+yarn build:web
+```
+
+Open `web/index.html` locally, or use the GitHub Pages deployment from this repository. The web UI supports:
+- escrow address lookup by chain, port, and channel
+- optional channel, connection, and client-state lookup sequence
+- configurable Lazy-LB base URL, using `/lb/{chain}/{rest-path}`
+- direct REST fallback through `https://rest.cosmos.directory/{chain}`
 
 ### Terminal UI
 ```bash
@@ -114,7 +125,9 @@ node dist/updateChains.js -f         # Force chain data update
 
 ### Build Commands
 ```bash
-yarn build              # Compile TypeScript
+yarn build              # Compile CLI and web TypeScript
+yarn build:cli          # Compile CLI TypeScript
+yarn build:web          # Compile web TypeScript into web/assets
 yarn dev                # Watch mode compilation
 yarn clean              # Remove build artifacts
 ```
@@ -132,6 +145,11 @@ yarn lint               # Biome check
 yarn lint:fix           # Biome auto-fix
 yarn format             # Biome formatting
 ```
+
+### Deployment
+GitHub Pages is deployed by `.github/workflows/pages.yml` on pushes to `main`.
+The workflow installs dependencies with Yarn, runs `yarn build:web`, and publishes
+the `web/` directory.
 
 ## Output Structure
 

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,15 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
   "files": {
-    "includes": ["src/**/*.ts", "README.md", "package.json", "tsconfig.json", "biome.json"]
+    "includes": [
+      "src/**/*.ts",
+      "web-src/**/*.ts",
+      "README.md",
+      "package.json",
+      "tsconfig.json",
+      "tsconfig.web.json",
+      "biome.json"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "dist/audit.js",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "npm run build:cli && npm run build:web",
+    "build:cli": "tsc",
+    "build:web": "tsc -p tsconfig.web.json",
     "dev": "tsc --watch",
     "start": "npm run build && node dist/audit.js",
     "quick": "npm run build && node dist/audit.js quick",
@@ -17,9 +19,9 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
-    "test": "node --import tsx --test \"src/**/*.test.ts\"",
-    "test:watch": "node --import tsx --test --watch \"src/**/*.test.ts\"",
-    "test:coverage": "node --import tsx --test --experimental-test-coverage \"src/**/*.test.ts\"",
+    "test": "node --import tsx --test \"src/**/*.test.ts\" \"web-src/**/*.test.ts\"",
+    "test:watch": "node --import tsx --test --watch \"src/**/*.test.ts\" \"web-src/**/*.test.ts\"",
+    "test:coverage": "node --import tsx --test --experimental-test-coverage \"src/**/*.test.ts\" \"web-src/**/*.test.ts\"",
     "clean": "rimraf dist"
   },
   "dependencies": {

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./web/assets",
+    "rootDir": "./web-src",
+    "declaration": false,
+    "sourceMap": false,
+    "types": [],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["web-src/**/*.ts"],
+  "exclude": ["web-src/**/*.test.ts"]
+}

--- a/web-src/app.ts
+++ b/web-src/app.ts
@@ -1,0 +1,374 @@
+import {
+  buildChannelDetails,
+  buildChannelPath,
+  buildClientStatePath,
+  buildConnectionPath,
+  buildEscrowAddressPath,
+  buildLookupUrl,
+  type ChannelDetails,
+  type ChannelResponse,
+  type ClientStateResponse,
+  type ConnectionResponse,
+  type EndpointMode,
+  extractClientId,
+  extractConnectionId,
+  type LookupUrlOptions,
+} from './lookup.js';
+
+interface AppSettings {
+  chainName: string;
+  channelId: string;
+  portId: string;
+  endpointMode: EndpointMode;
+  lazyLbBaseUrl: string;
+  includeDetails: boolean;
+}
+
+interface EscrowAddressResponse {
+  escrow_address?: string;
+}
+
+interface HistoryEntry {
+  chainName: string;
+  channelId: string;
+  portId: string;
+  escrowAddress: string;
+  source: string;
+  timestamp: number;
+}
+
+const STORAGE_KEY = 'ibc-escrow-web-settings';
+const HISTORY_KEY = 'ibc-escrow-web-history';
+const DEFAULT_SETTINGS: AppSettings = {
+  chainName: 'cosmoshub',
+  channelId: 'channel-141',
+  portId: 'transfer',
+  endpointMode: 'auto',
+  lazyLbBaseUrl: '',
+  includeDetails: true,
+};
+
+function byId<T extends HTMLElement>(id: string): T {
+  const element = document.getElementById(id);
+  if (!element) {
+    throw new Error(`Missing element: ${id}`);
+  }
+
+  return element as T;
+}
+
+const form = byId<HTMLFormElement>('lookup-form');
+const chainInput = byId<HTMLInputElement>('chain-name');
+const channelInput = byId<HTMLInputElement>('channel-id');
+const portInput = byId<HTMLInputElement>('port-id');
+const endpointModeInput = byId<HTMLSelectElement>('endpoint-mode');
+const lazyLbInput = byId<HTMLInputElement>('lazy-lb-base-url');
+const includeDetailsInput = byId<HTMLInputElement>('include-details');
+const submitButton = byId<HTMLButtonElement>('lookup-button');
+const resetButton = byId<HTMLButtonElement>('reset-button');
+const statusText = byId<HTMLSpanElement>('status-text');
+const statusDot = byId<HTMLSpanElement>('status-dot');
+const resultPanel = byId<HTMLElement>('result-panel');
+const resultBody = byId<HTMLElement>('result-body');
+const detailPanel = byId<HTMLElement>('detail-panel');
+const detailBody = byId<HTMLElement>('detail-body');
+const tracePanel = byId<HTMLElement>('trace-panel');
+const traceBody = byId<HTMLElement>('trace-body');
+const historyBody = byId<HTMLElement>('history-body');
+
+function loadSettings(): AppSettings {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}') as Partial<AppSettings>;
+    return { ...DEFAULT_SETTINGS, ...parsed };
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
+}
+
+function saveSettings(settings: AppSettings): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+}
+
+function readSettings(): AppSettings {
+  return {
+    chainName: chainInput.value.trim(),
+    channelId: channelInput.value.trim(),
+    portId: portInput.value.trim() || 'transfer',
+    endpointMode: endpointModeInput.value as EndpointMode,
+    lazyLbBaseUrl: lazyLbInput.value.trim(),
+    includeDetails: includeDetailsInput.checked,
+  };
+}
+
+function applySettings(settings: AppSettings): void {
+  chainInput.value = settings.chainName;
+  channelInput.value = settings.channelId;
+  portInput.value = settings.portId;
+  endpointModeInput.value = settings.endpointMode;
+  lazyLbInput.value = settings.lazyLbBaseUrl;
+  includeDetailsInput.checked = settings.includeDetails;
+}
+
+function setStatus(message: string, state: 'idle' | 'busy' | 'ok' | 'error' = 'idle'): void {
+  statusText.textContent = message;
+  statusDot.dataset.state = state;
+}
+
+function setBusy(isBusy: boolean): void {
+  submitButton.disabled = isBusy;
+  resetButton.disabled = isBusy;
+  form.toggleAttribute('aria-busy', isBusy);
+}
+
+function buildLookupOptions(settings: AppSettings): LookupUrlOptions {
+  return {
+    chainName: settings.chainName,
+    endpointMode: settings.endpointMode,
+    lazyLbBaseUrl: settings.lazyLbBaseUrl,
+  };
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), 15000);
+
+  try {
+    const response = await fetch(url, {
+      headers: { accept: 'application/json' },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} from ${url}`);
+    }
+
+    return await response.json();
+  } finally {
+    window.clearTimeout(timeout);
+  }
+}
+
+function clearNode(node: HTMLElement): void {
+  while (node.firstChild) {
+    node.removeChild(node.firstChild);
+  }
+}
+
+function appendKeyValue(parent: HTMLElement, label: string, value: string, canCopy = false): void {
+  const row = document.createElement('div');
+  row.className = 'kv-row';
+
+  const key = document.createElement('span');
+  key.className = 'kv-key';
+  key.textContent = label;
+
+  const val = document.createElement('span');
+  val.className = 'kv-value';
+  val.textContent = value || '-';
+
+  row.append(key, val);
+
+  if (canCopy && value) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'small-button';
+    button.textContent = 'Copy';
+    button.addEventListener('click', () => navigator.clipboard.writeText(value));
+    row.append(button);
+  }
+
+  parent.append(row);
+}
+
+function appendRequest(parent: HTMLElement, label: string, url: string): void {
+  const item = document.createElement('div');
+  item.className = 'trace-row';
+
+  const name = document.createElement('span');
+  name.className = 'trace-label';
+  name.textContent = label;
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.target = '_blank';
+  link.rel = 'noreferrer';
+  link.textContent = url;
+
+  item.append(name, link);
+  parent.append(item);
+}
+
+function renderEscrowResult(settings: AppSettings, escrowAddress: string, source: string): void {
+  clearNode(resultBody);
+  appendKeyValue(resultBody, 'Chain', settings.chainName);
+  appendKeyValue(resultBody, 'Port / channel', `${settings.portId}/${settings.channelId}`);
+  appendKeyValue(resultBody, 'Escrow address', escrowAddress, true);
+  appendKeyValue(resultBody, 'Source', source);
+  resultPanel.hidden = false;
+}
+
+function renderChannelDetails(details: ChannelDetails): void {
+  clearNode(detailBody);
+  appendKeyValue(detailBody, 'Counterparty channel', details.counterpartyChannelId);
+  appendKeyValue(detailBody, 'Counterparty port', details.counterpartyPortId);
+  appendKeyValue(detailBody, 'Connection', details.connectionId);
+  appendKeyValue(detailBody, 'Client', details.clientId);
+  appendKeyValue(detailBody, 'Counterparty client', details.counterpartyClientId);
+  appendKeyValue(detailBody, 'Counterparty connection', details.counterpartyConnectionId);
+  appendKeyValue(detailBody, 'Counterparty chain', details.counterpartyChainId);
+  appendKeyValue(detailBody, 'Ordering', details.ordering);
+  appendKeyValue(detailBody, 'Version', details.version);
+  detailPanel.hidden = false;
+}
+
+function renderTrace(requests: Array<{ label: string; url: string }>): void {
+  clearNode(traceBody);
+  for (const request of requests) {
+    appendRequest(traceBody, request.label, request.url);
+  }
+  tracePanel.hidden = requests.length === 0;
+}
+
+function loadHistory(): HistoryEntry[] {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(HISTORY_KEY) || '[]') as HistoryEntry[];
+    return Array.isArray(parsed) ? parsed.slice(0, 6) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveHistory(entry: HistoryEntry): void {
+  const history = loadHistory().filter(
+    (item) =>
+      !(
+        item.chainName === entry.chainName &&
+        item.channelId === entry.channelId &&
+        item.portId === entry.portId
+      )
+  );
+  localStorage.setItem(HISTORY_KEY, JSON.stringify([entry, ...history].slice(0, 6)));
+}
+
+function renderHistory(): void {
+  clearNode(historyBody);
+  const history = loadHistory();
+
+  if (history.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-state';
+    empty.textContent = 'No recent lookups';
+    historyBody.append(empty);
+    return;
+  }
+
+  for (const item of history) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'history-button';
+    button.textContent = `${item.chainName} ${item.channelId}`;
+    button.addEventListener('click', () => {
+      chainInput.value = item.chainName;
+      channelInput.value = item.channelId;
+      portInput.value = item.portId;
+      setStatus(`Loaded ${item.chainName} ${item.channelId}`, 'idle');
+    });
+    historyBody.append(button);
+  }
+}
+
+async function runLookup(settings: AppSettings): Promise<void> {
+  const options = buildLookupOptions(settings);
+  const requests: Array<{ label: string; url: string }> = [];
+
+  setStatus('Querying escrow address', 'busy');
+  const escrowPath = buildEscrowAddressPath(settings.channelId, settings.portId);
+  const escrowRequest = buildLookupUrl(options, escrowPath);
+  requests.push({ label: 'escrow', url: escrowRequest.url });
+  const escrowData = (await fetchJson(escrowRequest.url)) as EscrowAddressResponse;
+
+  if (!escrowData.escrow_address) {
+    throw new Error('Escrow address was not returned');
+  }
+
+  renderEscrowResult(settings, escrowData.escrow_address, escrowRequest.source);
+
+  if (settings.includeDetails) {
+    setStatus('Querying channel details', 'busy');
+    const channelRequest = buildLookupUrl(
+      options,
+      buildChannelPath(settings.channelId, settings.portId)
+    );
+    requests.push({ label: 'channel', url: channelRequest.url });
+    const channelData = (await fetchJson(channelRequest.url)) as ChannelResponse;
+    const connectionId = extractConnectionId(channelData);
+
+    const connectionRequest = buildLookupUrl(options, buildConnectionPath(connectionId));
+    requests.push({ label: 'connection', url: connectionRequest.url });
+    const connectionData = (await fetchJson(connectionRequest.url)) as ConnectionResponse;
+    const clientId = extractClientId(connectionData);
+
+    const clientRequest = buildLookupUrl(options, buildClientStatePath(clientId));
+    requests.push({ label: 'client', url: clientRequest.url });
+    const clientStateData = (await fetchJson(clientRequest.url)) as ClientStateResponse;
+
+    renderChannelDetails(buildChannelDetails(channelData, connectionData, clientStateData));
+  } else {
+    clearNode(detailBody);
+    detailPanel.hidden = true;
+  }
+
+  renderTrace(requests);
+  saveHistory({
+    chainName: settings.chainName,
+    channelId: settings.channelId,
+    portId: settings.portId,
+    escrowAddress: escrowData.escrow_address,
+    source: escrowRequest.source,
+    timestamp: Date.now(),
+  });
+  renderHistory();
+  setStatus('Lookup complete', 'ok');
+}
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const settings = readSettings();
+  saveSettings(settings);
+  setBusy(true);
+
+  try {
+    await runLookup(settings);
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : 'Lookup failed', 'error');
+  } finally {
+    setBusy(false);
+  }
+});
+
+resetButton.addEventListener('click', () => {
+  applySettings(DEFAULT_SETTINGS);
+  saveSettings(DEFAULT_SETTINGS);
+  clearNode(resultBody);
+  clearNode(detailBody);
+  clearNode(traceBody);
+  resultPanel.hidden = true;
+  detailPanel.hidden = true;
+  tracePanel.hidden = true;
+  setStatus('Ready', 'idle');
+});
+
+document.querySelectorAll<HTMLButtonElement>('[data-preset]').forEach((button) => {
+  button.addEventListener('click', () => {
+    const [chainName, channelId] = (button.dataset.preset || '').split(':');
+    if (!chainName || !channelId) return;
+    chainInput.value = chainName;
+    channelInput.value = channelId;
+    portInput.value = 'transfer';
+    setStatus(`Loaded ${chainName} ${channelId}`, 'idle');
+  });
+});
+
+applySettings(loadSettings());
+renderHistory();
+setStatus('Ready', 'idle');

--- a/web-src/lookup.test.ts
+++ b/web-src/lookup.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  buildChannelDetails,
+  buildChannelPath,
+  buildClientStatePath,
+  buildConnectionPath,
+  buildEscrowAddressPath,
+  buildLookupUrl,
+  resolveRequestSource,
+} from './lookup.ts';
+
+describe('web lookup helpers', () => {
+  it('builds transfer escrow and channel paths', () => {
+    assert.equal(
+      buildEscrowAddressPath('channel-141', 'transfer'),
+      '/ibc/apps/transfer/v1/channels/channel-141/ports/transfer/escrow_address'
+    );
+    assert.equal(
+      buildChannelPath('channel-141', 'transfer'),
+      '/ibc/core/channel/v1/channels/channel-141/ports/transfer'
+    );
+  });
+
+  it('builds direct REST and Lazy-LB URLs', () => {
+    const path = buildEscrowAddressPath('channel-141');
+
+    assert.deepEqual(
+      buildLookupUrl({ chainName: 'cosmoshub', endpointMode: 'direct-rest' }, path),
+      {
+        source: 'direct-rest',
+        url: 'https://rest.cosmos.directory/cosmoshub/ibc/apps/transfer/v1/channels/channel-141/ports/transfer/escrow_address',
+      }
+    );
+
+    assert.deepEqual(
+      buildLookupUrl(
+        {
+          chainName: 'cosmoshub',
+          endpointMode: 'lazy-lb',
+          lazyLbBaseUrl: 'https://lb.example.com/',
+        },
+        path
+      ),
+      {
+        source: 'lazy-lb',
+        url: 'https://lb.example.com/lb/cosmoshub/ibc/apps/transfer/v1/channels/channel-141/ports/transfer/escrow_address',
+      }
+    );
+  });
+
+  it('uses Lazy-LB automatically only when a base URL is configured', () => {
+    assert.equal(
+      resolveRequestSource({ chainName: 'osmosis', endpointMode: 'auto' }),
+      'direct-rest'
+    );
+    assert.equal(
+      resolveRequestSource({
+        chainName: 'osmosis',
+        endpointMode: 'auto',
+        lazyLbBaseUrl: 'https://lb.example.com',
+      }),
+      'lazy-lb'
+    );
+  });
+
+  it('builds dependent channel detail requests and summary data', () => {
+    assert.equal(
+      buildConnectionPath('connection-257'),
+      '/ibc/core/connection/v1/connections/connection-257'
+    );
+    assert.equal(
+      buildClientStatePath('07-tendermint-259'),
+      '/ibc/core/client/v1/client_states/07-tendermint-259'
+    );
+
+    assert.deepEqual(
+      buildChannelDetails(
+        {
+          channel: {
+            counterparty: { channel_id: 'channel-0', port_id: 'transfer' },
+            connection_hops: ['connection-257'],
+            ordering: 'ORDER_UNORDERED',
+            version: 'ics20-1',
+          },
+        },
+        {
+          connection: {
+            client_id: '07-tendermint-259',
+            counterparty: {
+              client_id: '07-tendermint-1',
+              connection_id: 'connection-1',
+            },
+          },
+        },
+        { client_state: { chain_id: 'osmosis-1' } }
+      ),
+      {
+        counterpartyChannelId: 'channel-0',
+        counterpartyPortId: 'transfer',
+        connectionId: 'connection-257',
+        clientId: '07-tendermint-259',
+        counterpartyClientId: '07-tendermint-1',
+        counterpartyConnectionId: 'connection-1',
+        counterpartyChainId: 'osmosis-1',
+        ordering: 'ORDER_UNORDERED',
+        version: 'ics20-1',
+      }
+    );
+  });
+});

--- a/web-src/lookup.ts
+++ b/web-src/lookup.ts
@@ -1,0 +1,200 @@
+export type EndpointMode = 'auto' | 'lazy-lb' | 'direct-rest';
+export type RequestSource = 'lazy-lb' | 'direct-rest';
+
+export interface LookupUrlOptions {
+  chainName: string;
+  endpointMode: EndpointMode;
+  lazyLbBaseUrl?: string;
+  directRestBaseUrl?: string;
+}
+
+export interface ResolvedLookupUrl {
+  url: string;
+  source: RequestSource;
+}
+
+export interface ChannelDetails {
+  counterpartyChannelId: string;
+  counterpartyPortId: string;
+  connectionId: string;
+  clientId: string;
+  counterpartyClientId: string;
+  counterpartyConnectionId: string;
+  counterpartyChainId: string;
+  ordering: string;
+  version: string;
+}
+
+export interface ChannelResponse {
+  channel?: {
+    counterparty?: {
+      channel_id?: string;
+      port_id?: string;
+    };
+    connection_hops?: string[];
+    ordering?: string;
+    version?: string;
+  };
+}
+
+export interface ConnectionResponse {
+  connection?: {
+    client_id?: string;
+    counterparty?: {
+      client_id?: string;
+      connection_id?: string;
+    };
+  };
+}
+
+export interface ClientStateResponse {
+  client_state?: {
+    chain_id?: string;
+  };
+  identified_client_state?: {
+    client_state?: {
+      chain_id?: string;
+    };
+  };
+}
+
+const DEFAULT_DIRECT_REST_BASE_URL = 'https://rest.cosmos.directory';
+
+export function validateChannelId(channelId: string): void {
+  if (!/^channel-\d+$/.test(channelId.trim())) {
+    throw new Error(`Invalid channel ID: ${channelId}`);
+  }
+}
+
+export function validatePortId(portId: string): void {
+  if (!/^[a-zA-Z0-9._/-]+$/.test(portId.trim())) {
+    throw new Error(`Invalid port ID: ${portId}`);
+  }
+}
+
+export function buildEscrowAddressPath(channelId: string, portId: string = 'transfer'): string {
+  validateChannelId(channelId);
+  validatePortId(portId);
+  return `/ibc/apps/transfer/v1/channels/${encodeURIComponent(
+    channelId.trim()
+  )}/ports/${encodeURIComponent(portId.trim())}/escrow_address`;
+}
+
+export function buildChannelPath(channelId: string, portId: string = 'transfer'): string {
+  validateChannelId(channelId);
+  validatePortId(portId);
+  return `/ibc/core/channel/v1/channels/${encodeURIComponent(
+    channelId.trim()
+  )}/ports/${encodeURIComponent(portId.trim())}`;
+}
+
+export function buildConnectionPath(connectionId: string): string {
+  if (!/^connection-\d+$/.test(connectionId.trim())) {
+    throw new Error(`Invalid connection ID: ${connectionId}`);
+  }
+
+  return `/ibc/core/connection/v1/connections/${encodeURIComponent(connectionId.trim())}`;
+}
+
+export function buildClientStatePath(clientId: string): string {
+  if (!/^[a-zA-Z0-9._-]+-\d+$/.test(clientId.trim())) {
+    throw new Error(`Invalid client ID: ${clientId}`);
+  }
+
+  return `/ibc/core/client/v1/client_states/${encodeURIComponent(clientId.trim())}`;
+}
+
+export function normalizeBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, '');
+}
+
+export function resolveRequestSource(options: LookupUrlOptions): RequestSource {
+  if (options.endpointMode === 'direct-rest') {
+    return 'direct-rest';
+  }
+
+  if (options.endpointMode === 'lazy-lb') {
+    return 'lazy-lb';
+  }
+
+  return options.lazyLbBaseUrl?.trim() ? 'lazy-lb' : 'direct-rest';
+}
+
+export function buildLookupUrl(options: LookupUrlOptions, requestPath: string): ResolvedLookupUrl {
+  const chainName = options.chainName.trim();
+  if (!chainName) {
+    throw new Error('Chain name is required');
+  }
+
+  const normalizedPath = requestPath.replace(/^\/+/, '');
+  const source = resolveRequestSource(options);
+
+  if (source === 'lazy-lb') {
+    const baseUrl = normalizeBaseUrl(options.lazyLbBaseUrl || '');
+    if (!baseUrl) {
+      throw new Error('Lazy-LB base URL is required for Lazy-LB mode');
+    }
+
+    return {
+      source,
+      url: `${baseUrl}/lb/${encodeURIComponent(chainName)}/${normalizedPath}`,
+    };
+  }
+
+  const directBaseUrl = normalizeBaseUrl(options.directRestBaseUrl || DEFAULT_DIRECT_REST_BASE_URL);
+  return {
+    source,
+    url: `${directBaseUrl}/${encodeURIComponent(chainName)}/${normalizedPath}`,
+  };
+}
+
+export function extractConnectionId(channelData: ChannelResponse): string {
+  const connectionId = channelData.channel?.connection_hops?.[0];
+  if (!connectionId) {
+    throw new Error('Channel response did not include a connection hop');
+  }
+
+  return connectionId;
+}
+
+export function extractClientId(connectionData: ConnectionResponse): string {
+  const clientId = connectionData.connection?.client_id;
+  if (!clientId) {
+    throw new Error('Connection response did not include a client ID');
+  }
+
+  return clientId;
+}
+
+export function extractCounterpartyChainId(clientStateData: ClientStateResponse): string {
+  return (
+    clientStateData.client_state?.chain_id ||
+    clientStateData.identified_client_state?.client_state?.chain_id ||
+    ''
+  );
+}
+
+export function buildChannelDetails(
+  channelData: ChannelResponse,
+  connectionData: ConnectionResponse,
+  clientStateData: ClientStateResponse
+): ChannelDetails {
+  const channel = channelData.channel;
+  const connection = connectionData.connection;
+
+  if (!channel || !connection) {
+    throw new Error('Channel detail responses were incomplete');
+  }
+
+  return {
+    counterpartyChannelId: channel.counterparty?.channel_id || '',
+    counterpartyPortId: channel.counterparty?.port_id || '',
+    connectionId: extractConnectionId(channelData),
+    clientId: extractClientId(connectionData),
+    counterpartyClientId: connection.counterparty?.client_id || '',
+    counterpartyConnectionId: connection.counterparty?.connection_id || '',
+    counterpartyChainId: extractCounterpartyChainId(clientStateData),
+    ordering: channel.ordering || '',
+    version: channel.version || '',
+  };
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="IBC escrow address lookup for Cosmos chains and transfer channels."
+    />
+    <title>IBC Escrow Explorer</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <script type="module" src="./assets/app.js"></script>
+  </head>
+  <body>
+    <main class="app-shell">
+      <header class="topbar">
+        <div>
+          <p class="eyebrow">IBC transfer module</p>
+          <h1>Escrow Explorer</h1>
+        </div>
+        <div class="status-pill" aria-live="polite">
+          <span id="status-dot" class="status-dot" data-state="idle"></span>
+          <span id="status-text">Ready</span>
+        </div>
+      </header>
+
+      <section class="workspace" aria-label="IBC escrow lookup">
+        <form id="lookup-form" class="panel control-panel">
+          <div class="panel-title">
+            <span>Lookup</span>
+            <span class="panel-rule"></span>
+          </div>
+
+          <div class="field-grid">
+            <label>
+              <span>Chain</span>
+              <input
+                id="chain-name"
+                name="chain"
+                list="chain-options"
+                autocomplete="off"
+                spellcheck="false"
+                required
+              />
+            </label>
+            <label>
+              <span>Channel</span>
+              <input
+                id="channel-id"
+                name="channel"
+                pattern="channel-[0-9]+"
+                autocomplete="off"
+                spellcheck="false"
+                required
+              />
+            </label>
+            <label>
+              <span>Port</span>
+              <input id="port-id" name="port" autocomplete="off" spellcheck="false" required />
+            </label>
+            <label>
+              <span>Endpoint</span>
+              <select id="endpoint-mode" name="endpointMode">
+                <option value="auto">Auto</option>
+                <option value="lazy-lb">Lazy-LB</option>
+                <option value="direct-rest">Direct REST</option>
+              </select>
+            </label>
+          </div>
+
+          <label class="wide-field">
+            <span>Lazy-LB base URL</span>
+            <input
+              id="lazy-lb-base-url"
+              name="lazyLbBaseUrl"
+              type="url"
+              placeholder="https://your-lazy-lb.example"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </label>
+
+          <div class="inline-options">
+            <label class="check-row">
+              <input id="include-details" type="checkbox" />
+              <span>Channel details</span>
+            </label>
+            <div class="actions">
+              <button id="reset-button" type="button" class="secondary-button">Reset</button>
+              <button id="lookup-button" type="submit" class="primary-button">Lookup</button>
+            </div>
+          </div>
+
+          <datalist id="chain-options">
+            <option value="cosmoshub"></option>
+            <option value="osmosis"></option>
+            <option value="neutron"></option>
+            <option value="noble"></option>
+            <option value="juno"></option>
+            <option value="stargaze"></option>
+            <option value="stride"></option>
+          </datalist>
+        </form>
+
+        <aside class="panel side-panel">
+          <div class="panel-title">
+            <span>Presets</span>
+            <span class="panel-rule"></span>
+          </div>
+          <div class="preset-list">
+            <button type="button" data-preset="cosmoshub:channel-141">cosmoshub channel-141</button>
+            <button type="button" data-preset="osmosis:channel-0">osmosis channel-0</button>
+            <button type="button" data-preset="noble:channel-4">noble channel-4</button>
+          </div>
+          <div class="panel-title compact">
+            <span>Recent</span>
+            <span class="panel-rule"></span>
+          </div>
+          <div id="history-body" class="history-list"></div>
+        </aside>
+      </section>
+
+      <section class="result-grid" aria-live="polite">
+        <article id="result-panel" class="panel result-panel" hidden>
+          <div class="panel-title">
+            <span>Escrow</span>
+            <span class="panel-rule"></span>
+          </div>
+          <div id="result-body" class="kv-list"></div>
+        </article>
+
+        <article id="detail-panel" class="panel result-panel" hidden>
+          <div class="panel-title">
+            <span>Channel</span>
+            <span class="panel-rule"></span>
+          </div>
+          <div id="detail-body" class="kv-list"></div>
+        </article>
+
+        <article id="trace-panel" class="panel trace-panel" hidden>
+          <div class="panel-title">
+            <span>Requests</span>
+            <span class="panel-rule"></span>
+          </div>
+          <div id="trace-body" class="trace-list"></div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,380 @@
+:root {
+  color-scheme: dark;
+  --bg: #0b0d0a;
+  --panel: #11140f;
+  --panel-strong: #161b14;
+  --line: #2d382b;
+  --line-bright: #688765;
+  --text: #edf4e9;
+  --muted: #9dac99;
+  --green: #78d66f;
+  --cyan: #74d5c6;
+  --amber: #efb35a;
+  --red: #f2777a;
+  --shadow: rgba(0, 0, 0, 0.38);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    linear-gradient(180deg, rgba(120, 214, 111, 0.05), transparent 280px),
+    var(--bg);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.app-shell {
+  width: min(1180px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 22px 0 38px;
+}
+
+.topbar {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 18px;
+  min-height: 78px;
+  margin-bottom: 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0 0 5px;
+  color: var(--cyan);
+  font: 600 0.75rem / 1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 13px;
+  font-size: clamp(1.9rem, 6vw, 3.7rem);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 168px;
+  margin-bottom: 16px;
+  padding: 9px 11px;
+  border: 1px solid var(--line);
+  background: rgba(17, 20, 15, 0.88);
+  color: var(--muted);
+  font: 600 0.78rem / 1 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border: 1px solid currentColor;
+  background: var(--muted);
+}
+
+.status-dot[data-state="busy"] {
+  color: var(--amber);
+  background: var(--amber);
+}
+
+.status-dot[data-state="ok"] {
+  color: var(--green);
+  background: var(--green);
+}
+
+.status-dot[data-state="error"] {
+  color: var(--red);
+  background: var(--red);
+}
+
+.workspace,
+.result-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.workspace {
+  grid-template-columns: minmax(0, 1fr) 320px;
+  align-items: start;
+}
+
+.result-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 16px;
+}
+
+.trace-panel {
+  grid-column: 1 / -1;
+}
+
+.panel {
+  border: 1px solid var(--line);
+  background: linear-gradient(180deg, var(--panel-strong), var(--panel));
+  box-shadow: 0 18px 38px var(--shadow);
+}
+
+.panel-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--line);
+  color: var(--green);
+  font: 700 0.78rem / 1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-transform: uppercase;
+}
+
+.panel-title.compact {
+  margin-top: 10px;
+}
+
+.panel-rule {
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, var(--line-bright), transparent);
+}
+
+.control-panel {
+  padding-bottom: 14px;
+}
+
+.field-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr 0.8fr 0.9fr;
+  gap: 12px;
+  padding: 14px;
+}
+
+label {
+  display: grid;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+label span {
+  font: 700 0.72rem / 1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-transform: uppercase;
+}
+
+input,
+select {
+  width: 100%;
+  min-height: 42px;
+  border: 1px solid var(--line);
+  border-radius: 0;
+  background: #090b08;
+  color: var(--text);
+  padding: 9px 10px;
+  outline: none;
+}
+
+input:focus,
+select:focus {
+  border-color: var(--green);
+  box-shadow: 0 0 0 2px rgba(120, 214, 111, 0.18);
+}
+
+.wide-field {
+  padding: 0 14px 14px;
+}
+
+.inline-options {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 0 14px;
+}
+
+.check-row {
+  display: flex;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 9px;
+}
+
+.check-row input {
+  width: 18px;
+  min-height: 18px;
+  accent-color: var(--green);
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+}
+
+.primary-button,
+.secondary-button,
+.small-button,
+.preset-list button,
+.history-button {
+  min-height: 38px;
+  border: 1px solid var(--line-bright);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text);
+  padding: 8px 12px;
+  font: 700 0.78rem / 1 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.primary-button {
+  background: var(--green);
+  border-color: var(--green);
+  color: #071006;
+}
+
+.secondary-button:hover,
+.small-button:hover,
+.preset-list button:hover,
+.history-button:hover {
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+
+.side-panel {
+  min-height: 294px;
+}
+
+.preset-list,
+.history-list {
+  display: grid;
+  gap: 8px;
+  padding: 12px 14px;
+}
+
+.preset-list button,
+.history-button {
+  width: 100%;
+  text-align: left;
+}
+
+.empty-state {
+  margin: 0;
+  color: var(--muted);
+  font: 0.86rem / 1.45 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.result-panel,
+.trace-panel {
+  min-height: 184px;
+}
+
+.kv-list,
+.trace-list {
+  display: grid;
+  gap: 0;
+  padding: 4px 14px 14px;
+}
+
+.kv-row,
+.trace-row {
+  display: grid;
+  grid-template-columns: 190px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  min-height: 42px;
+  border-bottom: 1px solid rgba(104, 135, 101, 0.22);
+}
+
+.kv-key,
+.trace-label {
+  color: var(--muted);
+  font: 700 0.72rem / 1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-transform: uppercase;
+}
+
+.kv-value,
+.trace-row a {
+  overflow-wrap: anywhere;
+  color: var(--text);
+  font: 0.92rem / 1.35 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.trace-row {
+  grid-template-columns: 120px minmax(0, 1fr);
+}
+
+.trace-row a {
+  color: var(--cyan);
+  text-decoration: none;
+}
+
+.trace-row a:hover {
+  text-decoration: underline;
+}
+
+.small-button {
+  min-height: 30px;
+  padding: 6px 9px;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 920px) {
+  .workspace,
+  .result-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .field-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 620px) {
+  .app-shell {
+    width: min(100vw - 20px, 1180px);
+    padding-top: 12px;
+  }
+
+  .topbar,
+  .inline-options {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .status-pill,
+  .actions,
+  .primary-button,
+  .secondary-button {
+    width: 100%;
+  }
+
+  .field-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .kv-row,
+  .trace-row {
+    grid-template-columns: 1fr;
+    gap: 5px;
+    padding: 10px 0;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a static TypeScript-powered web UI for escrow address and channel detail lookup
- Support Lazy-LB universal endpoint URLs with direct rest.cosmos.directory fallback
- Add web helper tests, web TypeScript build, and GitHub Pages workflow

## Test Plan
- npm test
- npm run lint
- npm run build
- Playwright headless browser lookup against http://127.0.0.1:4173/ for cosmoshub channel-141
- Desktop and mobile screenshots checked for layout fit