### PR TITLE
[codex] Add hosted escrow balance lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ yarn build:web
 
 Open `web/index.html` locally, or use the GitHub Pages deployment from this repository. The web UI supports:
 - escrow address lookup by chain, port, and channel
+- escrow balance lookup through paginated bank balance requests
 - optional channel, connection, and client-state lookup sequence
-- configurable Lazy-LB base URL, using `/lb/{chain}/{rest-path}`
+- hosted Lazy-LB routing through `/lb/{chain}/{rest-path}` with no user-entered service URL
 - direct REST fallback through `https://rest.cosmos.directory/{chain}`
 
 ### Terminal UI
@@ -147,6 +148,11 @@ yarn format             # Biome formatting
 ```
 
 ### Deployment
+The public web app is served at `https://ibc-escrow.cac-group.io/`. Caddy serves
+the static `web/` assets from `/srv/ibc-escrow` and reverse proxies same-origin
+`/lb/*` requests to the lazy-lb service in the `ibc-escrow` LXC container on
+`10.70.48.173:3000`.
+
 GitHub Pages is deployed by `.github/workflows/pages.yml` on pushes to `main`.
 The workflow installs dependencies with Yarn, runs `yarn build:web`, and publishes
 the `web/` directory.

--- a/web-src/app.ts
+++ b/web-src/app.ts
@@ -1,4 +1,7 @@
 import {
+  type BalanceRow,
+  type BalancesResponse,
+  buildBalancesPath,
   buildChannelDetails,
   buildChannelPath,
   buildClientStatePath,
@@ -12,7 +15,9 @@ import {
   type EndpointMode,
   extractClientId,
   extractConnectionId,
+  getNextBalancePageKey,
   type LookupUrlOptions,
+  normalizeBalances,
 } from './lookup.js';
 
 interface AppSettings {
@@ -39,14 +44,27 @@ interface HistoryEntry {
 
 const STORAGE_KEY = 'ibc-escrow-web-settings';
 const HISTORY_KEY = 'ibc-escrow-web-history';
-const DEFAULT_SETTINGS: AppSettings = {
-  chainName: 'cosmoshub',
-  channelId: 'channel-141',
-  portId: 'transfer',
-  endpointMode: 'auto',
-  lazyLbBaseUrl: '',
-  includeDetails: true,
-};
+const HOSTED_LAZY_LB_BASE_URL = 'https://ibc-escrow.cac-group.io';
+
+function getDefaultLazyLbBaseUrl(): string {
+  const origin = window.location.origin;
+  if (origin === HOSTED_LAZY_LB_BASE_URL) {
+    return origin;
+  }
+
+  return HOSTED_LAZY_LB_BASE_URL;
+}
+
+function getDefaultSettings(): AppSettings {
+  return {
+    chainName: 'cosmoshub',
+    channelId: 'channel-141',
+    portId: 'transfer',
+    endpointMode: 'auto',
+    lazyLbBaseUrl: getDefaultLazyLbBaseUrl(),
+    includeDetails: true,
+  };
+}
 
 function byId<T extends HTMLElement>(id: string): T {
   const element = document.getElementById(id);
@@ -70,6 +88,9 @@ const statusText = byId<HTMLSpanElement>('status-text');
 const statusDot = byId<HTMLSpanElement>('status-dot');
 const resultPanel = byId<HTMLElement>('result-panel');
 const resultBody = byId<HTMLElement>('result-body');
+const balancesPanel = byId<HTMLElement>('balances-panel');
+const balancesTitle = byId<HTMLElement>('balances-title');
+const balancesBody = byId<HTMLElement>('balances-body');
 const detailPanel = byId<HTMLElement>('detail-panel');
 const detailBody = byId<HTMLElement>('detail-body');
 const tracePanel = byId<HTMLElement>('trace-panel');
@@ -77,11 +98,16 @@ const traceBody = byId<HTMLElement>('trace-body');
 const historyBody = byId<HTMLElement>('history-body');
 
 function loadSettings(): AppSettings {
+  const defaults = getDefaultSettings();
   try {
     const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}') as Partial<AppSettings>;
-    return { ...DEFAULT_SETTINGS, ...parsed };
+    return {
+      ...defaults,
+      ...parsed,
+      lazyLbBaseUrl: parsed.lazyLbBaseUrl?.trim() || defaults.lazyLbBaseUrl,
+    };
   } catch {
-    return DEFAULT_SETTINGS;
+    return defaults;
   }
 }
 
@@ -124,7 +150,7 @@ function buildLookupOptions(settings: AppSettings): LookupUrlOptions {
   return {
     chainName: settings.chainName,
     endpointMode: settings.endpointMode,
-    lazyLbBaseUrl: settings.lazyLbBaseUrl,
+    lazyLbBaseUrl: settings.lazyLbBaseUrl || getDefaultLazyLbBaseUrl(),
   };
 }
 
@@ -221,6 +247,67 @@ function renderChannelDetails(details: ChannelDetails): void {
   detailPanel.hidden = false;
 }
 
+function renderBalances(balances: BalanceRow[]): void {
+  clearNode(balancesBody);
+  balancesTitle.textContent = `Balances (${balances.length})`;
+
+  if (balances.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-state';
+    empty.textContent = 'No balances returned for this escrow account';
+    balancesBody.append(empty);
+    balancesPanel.hidden = false;
+    return;
+  }
+
+  for (const balance of balances) {
+    const row = document.createElement('div');
+    row.className = 'balance-row';
+
+    const amount = document.createElement('span');
+    amount.className = 'balance-amount';
+    amount.textContent = balance.amount;
+
+    const denom = document.createElement('span');
+    denom.className = 'balance-denom';
+    denom.textContent = balance.denom;
+
+    row.append(amount, denom);
+    balancesBody.append(row);
+  }
+
+  balancesPanel.hidden = false;
+}
+
+async function fetchAllBalances(
+  options: LookupUrlOptions,
+  escrowAddress: string,
+  requests: Array<{ label: string; url: string }>
+): Promise<BalanceRow[]> {
+  const balances: BalanceRow[] = [];
+  let paginationKey: string | undefined;
+
+  for (let page = 0; page < 20; page += 1) {
+    const balancesRequest = buildLookupUrl(
+      options,
+      buildBalancesPath(escrowAddress, paginationKey)
+    );
+    requests.push({
+      label: page === 0 ? 'balances' : `balances ${page + 1}`,
+      url: balancesRequest.url,
+    });
+    const balancesData = (await fetchJson(balancesRequest.url)) as BalancesResponse;
+    balances.push(...normalizeBalances(balancesData));
+
+    paginationKey = getNextBalancePageKey(balancesData);
+    if (!paginationKey) {
+      return balances;
+    }
+  }
+
+  throw new Error('Balance lookup exceeded pagination limit');
+}
+
 function renderTrace(requests: Array<{ label: string; url: string }>): void {
   clearNode(traceBody);
   for (const request of requests) {
@@ -293,6 +380,10 @@ async function runLookup(settings: AppSettings): Promise<void> {
 
   renderEscrowResult(settings, escrowData.escrow_address, escrowRequest.source);
 
+  setStatus('Querying escrow balances', 'busy');
+  const balances = await fetchAllBalances(options, escrowData.escrow_address, requests);
+  renderBalances(balances);
+
   if (settings.includeDetails) {
     setStatus('Querying channel details', 'busy');
     const channelRequest = buildLookupUrl(
@@ -347,12 +438,16 @@ form.addEventListener('submit', async (event) => {
 });
 
 resetButton.addEventListener('click', () => {
-  applySettings(DEFAULT_SETTINGS);
-  saveSettings(DEFAULT_SETTINGS);
+  const defaultSettings = getDefaultSettings();
+  applySettings(defaultSettings);
+  saveSettings(defaultSettings);
   clearNode(resultBody);
+  clearNode(balancesBody);
+  balancesTitle.textContent = 'Balances';
   clearNode(detailBody);
   clearNode(traceBody);
   resultPanel.hidden = true;
+  balancesPanel.hidden = true;
   detailPanel.hidden = true;
   tracePanel.hidden = true;
   setStatus('Ready', 'idle');

--- a/web-src/lookup.test.ts
+++ b/web-src/lookup.test.ts
@@ -1,12 +1,15 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+  buildBalancesPath,
   buildChannelDetails,
   buildChannelPath,
   buildClientStatePath,
   buildConnectionPath,
   buildEscrowAddressPath,
   buildLookupUrl,
+  getNextBalancePageKey,
+  normalizeBalances,
   resolveRequestSource,
 } from './lookup.ts';
 
@@ -20,6 +23,37 @@ describe('web lookup helpers', () => {
       buildChannelPath('channel-141', 'transfer'),
       '/ibc/core/channel/v1/channels/channel-141/ports/transfer'
     );
+  });
+
+  it('builds bank balance paths for escrow addresses', () => {
+    assert.equal(
+      buildBalancesPath('cosmos1x54ltnyg88k0ejmk8ytwrhd3ltm84xehrnlslf'),
+      '/cosmos/bank/v1beta1/balances/cosmos1x54ltnyg88k0ejmk8ytwrhd3ltm84xehrnlslf'
+    );
+    assert.equal(
+      buildBalancesPath('cosmos1x54ltnyg88k0ejmk8ytwrhd3ltm84xehrnlslf', 'a/b='),
+      '/cosmos/bank/v1beta1/balances/cosmos1x54ltnyg88k0ejmk8ytwrhd3ltm84xehrnlslf?pagination.key=a%2Fb%3D'
+    );
+  });
+
+  it('normalizes bank balance responses and pagination', () => {
+    assert.deepEqual(
+      normalizeBalances({
+        balances: [
+          { denom: 'uatom', amount: '12345' },
+          { denom: 'ibc/ABC', amount: '67890' },
+          { denom: '', amount: '1' },
+        ],
+      }),
+      [
+        { denom: 'uatom', amount: '12345' },
+        { denom: 'ibc/ABC', amount: '67890' },
+      ]
+    );
+
+    assert.deepEqual(normalizeBalances({}), []);
+    assert.equal(getNextBalancePageKey({ pagination: { next_key: 'next-page' } }), 'next-page');
+    assert.equal(getNextBalancePageKey({ pagination: { next_key: null } }), undefined);
   });
 
   it('builds direct REST and Lazy-LB URLs', () => {

--- a/web-src/lookup.ts
+++ b/web-src/lookup.ts
@@ -25,6 +25,22 @@ export interface ChannelDetails {
   version: string;
 }
 
+export interface BalanceRow {
+  denom: string;
+  amount: string;
+}
+
+export interface BalancesResponse {
+  balances?: Array<{
+    denom?: string;
+    amount?: string;
+  }>;
+  pagination?: {
+    next_key?: string | null;
+    total?: string;
+  };
+}
+
 export interface ChannelResponse {
   channel?: {
     counterparty?: {
@@ -102,6 +118,34 @@ export function buildClientStatePath(clientId: string): string {
   }
 
   return `/ibc/core/client/v1/client_states/${encodeURIComponent(clientId.trim())}`;
+}
+
+export function buildBalancesPath(address: string, paginationKey?: string): string {
+  const cleanAddress = address.trim();
+  if (!/^[a-z0-9]+1[ac-hj-np-z02-9]+$/i.test(cleanAddress)) {
+    throw new Error(`Invalid account address: ${address}`);
+  }
+
+  const path = `/cosmos/bank/v1beta1/balances/${encodeURIComponent(cleanAddress)}`;
+  if (!paginationKey) {
+    return path;
+  }
+
+  const query = new URLSearchParams({ 'pagination.key': paginationKey });
+  return `${path}?${query.toString()}`;
+}
+
+export function normalizeBalances(response: BalancesResponse): BalanceRow[] {
+  return (response.balances || [])
+    .filter((balance) => balance.denom && balance.amount)
+    .map((balance) => ({
+      denom: balance.denom as string,
+      amount: balance.amount as string,
+    }));
+}
+
+export function getNextBalancePageKey(response: BalancesResponse): string | undefined {
+  return response.pagination?.next_key || undefined;
 }
 
 export function normalizeBaseUrl(url: string): string {

--- a/web/index.html
+++ b/web/index.html
@@ -68,17 +68,7 @@
             </label>
           </div>
 
-          <label class="wide-field">
-            <span>Lazy-LB base URL</span>
-            <input
-              id="lazy-lb-base-url"
-              name="lazyLbBaseUrl"
-              type="url"
-              placeholder="https://your-lazy-lb.example"
-              autocomplete="off"
-              spellcheck="false"
-            />
-          </label>
+          <input id="lazy-lb-base-url" name="lazyLbBaseUrl" type="hidden" />
 
           <div class="inline-options">
             <label class="check-row">
@@ -135,6 +125,14 @@
             <span class="panel-rule"></span>
           </div>
           <div id="detail-body" class="kv-list"></div>
+        </article>
+
+        <article id="balances-panel" class="panel trace-panel" hidden>
+          <div class="panel-title">
+            <span id="balances-title">Balances</span>
+            <span class="panel-rule"></span>
+          </div>
+          <div id="balances-body" class="balance-list"></div>
         </article>
 
         <article id="trace-panel" class="panel trace-panel" hidden>

--- a/web/styles.css
+++ b/web/styles.css
@@ -285,7 +285,8 @@ select:focus {
 }
 
 .kv-list,
-.trace-list {
+.trace-list,
+.balance-list {
   display: grid;
   gap: 0;
   padding: 4px 14px 14px;
@@ -317,6 +318,28 @@ select:focus {
 
 .trace-row {
   grid-template-columns: 120px minmax(0, 1fr);
+}
+
+.balance-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 0.35fr) minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+  min-height: 42px;
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(104, 135, 101, 0.22);
+}
+
+.balance-amount {
+  color: var(--green);
+  font: 0.92rem / 1.35 ui-monospace, SFMono-Regular, Menlo, monospace;
+  overflow-wrap: anywhere;
+}
+
+.balance-denom {
+  color: var(--text);
+  font: 0.88rem / 1.35 ui-monospace, SFMono-Regular, Menlo, monospace;
+  overflow-wrap: anywhere;
 }
 
 .trace-row a {
@@ -372,7 +395,8 @@ select:focus {
   }
 
   .kv-row,
-  .trace-row {
+  .trace-row,
+  .balance-row {
     grid-template-columns: 1fr;
     gap: 5px;
     padding: 10px 0;


### PR DESCRIPTION
## Summary
- default the web app to the hosted lazy-lb service instead of asking users for a Lazy-LB URL
- add escrow bank balance lookup, including pagination across all balance pages
- document the self-hosted Caddy/LXC deployment at `https://ibc-escrow.cac-group.io/`

## Validation
- `npm test`
- `npm run lint`
- `npm run build`
- browser check against `https://ibc-escrow.cac-group.io/`: lookup completed through lazy-lb, rendered `Balances (248)`, made 7 `/lb` requests, and had no failed browser requests
- service check: `lazy-lb` is active and enabled in the `ibc-escrow` LXC container
