### PR TITLE
[codex] Add registry chain selection and direct REST input

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Open `web/index.html` locally, or use the GitHub Pages deployment from this repo
 - escrow address lookup by chain, port, and channel
 - escrow balance lookup through paginated bank balance requests
 - optional channel, connection, and client-state lookup sequence
+- registry-backed chain selection populated from the hosted Lazy-LB chain summary API
 - hosted Lazy-LB routing through `/lb/{chain}/{rest-path}` with no user-entered service URL
-- direct REST fallback through `https://rest.cosmos.directory/{chain}`
+- direct REST fallback through `https://rest.cosmos.directory/{chain}`, or an explicit chain-specific REST endpoint entered in the UI
 
 ### Terminal UI
 ```bash
@@ -151,7 +152,10 @@ yarn format             # Biome formatting
 The public web app is served at `https://ibc-escrow.cac-group.io/`. Caddy serves
 the static `web/` assets from `/srv/ibc-escrow` and reverse proxies same-origin
 `/lb/*` requests to the lazy-lb service in the `ibc-escrow` LXC container on
-`10.70.48.173:3000`.
+`10.70.48.173:3000`. It also exposes the read-only `/api/chains-summary`
+metadata endpoint for chain selection. Chain registry metadata is used for
+discovery and endpoint coverage, while escrow addresses, balances, and channel
+details are always fetched from live chain REST responses.
 
 GitHub Pages is deployed by `.github/workflows/pages.yml` on pushes to `main`.
 The workflow installs dependencies with Yarn, runs `yarn build:web`, and publishes

--- a/web-src/app.ts
+++ b/web-src/app.ts
@@ -8,6 +8,7 @@ import {
   buildConnectionPath,
   buildEscrowAddressPath,
   buildLookupUrl,
+  type ChainSummary,
   type ChannelDetails,
   type ChannelResponse,
   type ClientStateResponse,
@@ -18,6 +19,8 @@ import {
   getNextBalancePageKey,
   type LookupUrlOptions,
   normalizeBalances,
+  normalizeBaseUrl,
+  normalizeChainSummaries,
 } from './lookup.js';
 
 interface AppSettings {
@@ -26,6 +29,7 @@ interface AppSettings {
   portId: string;
   endpointMode: EndpointMode;
   lazyLbBaseUrl: string;
+  directRestBaseUrl: string;
   includeDetails: boolean;
 }
 
@@ -45,6 +49,32 @@ interface HistoryEntry {
 const STORAGE_KEY = 'ibc-escrow-web-settings';
 const HISTORY_KEY = 'ibc-escrow-web-history';
 const HOSTED_LAZY_LB_BASE_URL = 'https://ibc-escrow.cac-group.io';
+const FALLBACK_CHAINS: ChainSummary[] = [
+  {
+    name: 'cosmoshub',
+    chainId: 'cosmoshub-4',
+    bech32Prefix: 'cosmos',
+    endpointCount: 0,
+    rpcCount: 0,
+    restCount: 0,
+  },
+  {
+    name: 'osmosis',
+    chainId: 'osmosis-1',
+    bech32Prefix: 'osmo',
+    endpointCount: 0,
+    rpcCount: 0,
+    restCount: 0,
+  },
+  {
+    name: 'noble',
+    chainId: 'noble-1',
+    bech32Prefix: 'noble',
+    endpointCount: 0,
+    rpcCount: 0,
+    restCount: 0,
+  },
+];
 
 function getDefaultLazyLbBaseUrl(): string {
   const origin = window.location.origin;
@@ -62,6 +92,7 @@ function getDefaultSettings(): AppSettings {
     portId: 'transfer',
     endpointMode: 'auto',
     lazyLbBaseUrl: getDefaultLazyLbBaseUrl(),
+    directRestBaseUrl: '',
     includeDetails: true,
   };
 }
@@ -81,6 +112,8 @@ const channelInput = byId<HTMLInputElement>('channel-id');
 const portInput = byId<HTMLInputElement>('port-id');
 const endpointModeInput = byId<HTMLSelectElement>('endpoint-mode');
 const lazyLbInput = byId<HTMLInputElement>('lazy-lb-base-url');
+const directRestField = byId<HTMLElement>('direct-rest-field');
+const directRestInput = byId<HTMLInputElement>('direct-rest-base-url');
 const includeDetailsInput = byId<HTMLInputElement>('include-details');
 const submitButton = byId<HTMLButtonElement>('lookup-button');
 const resetButton = byId<HTMLButtonElement>('reset-button');
@@ -96,6 +129,8 @@ const detailBody = byId<HTMLElement>('detail-body');
 const tracePanel = byId<HTMLElement>('trace-panel');
 const traceBody = byId<HTMLElement>('trace-body');
 const historyBody = byId<HTMLElement>('history-body');
+const chainOptions = byId<HTMLDataListElement>('chain-options');
+const chainSummaryStatus = byId<HTMLElement>('chain-summary-status');
 
 function loadSettings(): AppSettings {
   const defaults = getDefaultSettings();
@@ -122,6 +157,7 @@ function readSettings(): AppSettings {
     portId: portInput.value.trim() || 'transfer',
     endpointMode: endpointModeInput.value as EndpointMode,
     lazyLbBaseUrl: lazyLbInput.value.trim(),
+    directRestBaseUrl: directRestInput.value.trim(),
     includeDetails: includeDetailsInput.checked,
   };
 }
@@ -132,7 +168,9 @@ function applySettings(settings: AppSettings): void {
   portInput.value = settings.portId;
   endpointModeInput.value = settings.endpointMode;
   lazyLbInput.value = settings.lazyLbBaseUrl;
+  directRestInput.value = settings.directRestBaseUrl;
   includeDetailsInput.checked = settings.includeDetails;
+  updateEndpointFields();
 }
 
 function setStatus(message: string, state: 'idle' | 'busy' | 'ok' | 'error' = 'idle'): void {
@@ -151,7 +189,23 @@ function buildLookupOptions(settings: AppSettings): LookupUrlOptions {
     chainName: settings.chainName,
     endpointMode: settings.endpointMode,
     lazyLbBaseUrl: settings.lazyLbBaseUrl || getDefaultLazyLbBaseUrl(),
+    directRestBaseUrl: settings.directRestBaseUrl,
   };
+}
+
+function getDefaultDirectRestBaseUrl(): string {
+  return `https://rest.cosmos.directory/${encodeURIComponent(chainInput.value.trim() || 'cosmoshub')}`;
+}
+
+function updateEndpointFields(): void {
+  const directRestSelected = endpointModeInput.value === 'direct-rest';
+  directRestField.hidden = !directRestSelected;
+  directRestInput.placeholder = getDefaultDirectRestBaseUrl();
+}
+
+function buildServiceUrl(path: string): string {
+  const baseUrl = normalizeBaseUrl(lazyLbInput.value || getDefaultLazyLbBaseUrl());
+  return `${baseUrl}${path.startsWith('/') ? path : `/${path}`}`;
 }
 
 async function fetchJson(url: string): Promise<unknown> {
@@ -222,6 +276,33 @@ function appendRequest(parent: HTMLElement, label: string, url: string): void {
 
   item.append(name, link);
   parent.append(item);
+}
+
+function renderChainOptions(chains: ChainSummary[]): void {
+  clearNode(chainOptions);
+
+  for (const chain of chains) {
+    const option = document.createElement('option');
+    option.value = chain.name;
+    option.label = `${chain.chainId} · REST ${chain.restCount} · RPC ${chain.rpcCount}`;
+    chainOptions.append(option);
+  }
+}
+
+async function loadChainSummaries(): Promise<void> {
+  try {
+    const data = await fetchJson(buildServiceUrl('/api/chains-summary'));
+    const chains = normalizeChainSummaries(data);
+    if (chains.length === 0) {
+      throw new Error('No chain summaries returned');
+    }
+
+    renderChainOptions(chains);
+    chainSummaryStatus.textContent = `${chains.length} registry chains`;
+  } catch {
+    renderChainOptions(FALLBACK_CHAINS);
+    chainSummaryStatus.textContent = 'Registry list unavailable';
+  }
 }
 
 function renderEscrowResult(settings: AppSettings, escrowAddress: string, source: string): void {
@@ -358,6 +439,7 @@ function renderHistory(): void {
       chainInput.value = item.chainName;
       channelInput.value = item.channelId;
       portInput.value = item.portId;
+      updateEndpointFields();
       setStatus(`Loaded ${item.chainName} ${item.channelId}`, 'idle');
     });
     historyBody.append(button);
@@ -453,6 +535,9 @@ resetButton.addEventListener('click', () => {
   setStatus('Ready', 'idle');
 });
 
+endpointModeInput.addEventListener('change', updateEndpointFields);
+chainInput.addEventListener('input', updateEndpointFields);
+
 document.querySelectorAll<HTMLButtonElement>('[data-preset]').forEach((button) => {
   button.addEventListener('click', () => {
     const [chainName, channelId] = (button.dataset.preset || '').split(':');
@@ -460,10 +545,12 @@ document.querySelectorAll<HTMLButtonElement>('[data-preset]').forEach((button) =
     chainInput.value = chainName;
     channelInput.value = channelId;
     portInput.value = 'transfer';
+    updateEndpointFields();
     setStatus(`Loaded ${chainName} ${channelId}`, 'idle');
   });
 });
 
 applySettings(loadSettings());
+void loadChainSummaries();
 renderHistory();
 setStatus('Ready', 'idle');

--- a/web-src/lookup.test.ts
+++ b/web-src/lookup.test.ts
@@ -10,6 +10,7 @@ import {
   buildLookupUrl,
   getNextBalancePageKey,
   normalizeBalances,
+  normalizeChainSummaries,
   resolveRequestSource,
 } from './lookup.ts';
 
@@ -71,6 +72,21 @@ describe('web lookup helpers', () => {
       buildLookupUrl(
         {
           chainName: 'cosmoshub',
+          endpointMode: 'direct-rest',
+          directRestBaseUrl: 'https://lcd.example.com/cosmoshub/',
+        },
+        path
+      ),
+      {
+        source: 'direct-rest',
+        url: 'https://lcd.example.com/cosmoshub/ibc/apps/transfer/v1/channels/channel-141/ports/transfer/escrow_address',
+      }
+    );
+
+    assert.deepEqual(
+      buildLookupUrl(
+        {
+          chainName: 'cosmoshub',
           endpointMode: 'lazy-lb',
           lazyLbBaseUrl: 'https://lb.example.com/',
         },
@@ -96,6 +112,52 @@ describe('web lookup helpers', () => {
       }),
       'lazy-lb'
     );
+  });
+
+  it('normalizes chain-registry summaries for selection', () => {
+    assert.deepEqual(
+      normalizeChainSummaries([
+        {
+          name: 'osmosis',
+          chainId: 'osmosis-1',
+          bech32Prefix: 'osmo',
+          endpointCount: 12,
+          rpcCount: 6,
+          restCount: 6,
+          source: 'chain-registry',
+        },
+        {
+          name: 'cosmoshub',
+          chainId: 'cosmoshub-4',
+          bech32Prefix: 'cosmos',
+          endpointCount: 63,
+          rpcCount: 34,
+          restCount: 29,
+          source: 'chain-registry',
+        },
+        { name: '', chainId: 'bad' },
+      ]),
+      [
+        {
+          name: 'cosmoshub',
+          chainId: 'cosmoshub-4',
+          bech32Prefix: 'cosmos',
+          endpointCount: 63,
+          rpcCount: 34,
+          restCount: 29,
+        },
+        {
+          name: 'osmosis',
+          chainId: 'osmosis-1',
+          bech32Prefix: 'osmo',
+          endpointCount: 12,
+          rpcCount: 6,
+          restCount: 6,
+        },
+      ]
+    );
+
+    assert.deepEqual(normalizeChainSummaries({}), []);
   });
 
   it('builds dependent channel detail requests and summary data', () => {

--- a/web-src/lookup.ts
+++ b/web-src/lookup.ts
@@ -30,6 +30,24 @@ export interface BalanceRow {
   amount: string;
 }
 
+export interface ChainSummary {
+  name: string;
+  chainId: string;
+  bech32Prefix: string;
+  endpointCount: number;
+  rpcCount: number;
+  restCount: number;
+}
+
+interface ChainSummaryResponseItem {
+  name?: string;
+  chainId?: string;
+  bech32Prefix?: string;
+  endpointCount?: number;
+  rpcCount?: number;
+  restCount?: number;
+}
+
 export interface BalancesResponse {
   balances?: Array<{
     denom?: string;
@@ -148,6 +166,27 @@ export function getNextBalancePageKey(response: BalancesResponse): string | unde
   return response.pagination?.next_key || undefined;
 }
 
+export function normalizeChainSummaries(response: unknown): ChainSummary[] {
+  if (!Array.isArray(response)) {
+    return [];
+  }
+
+  return response
+    .filter((item): item is ChainSummaryResponseItem => {
+      const candidate = item as ChainSummaryResponseItem;
+      return Boolean(candidate.name?.trim() && candidate.chainId?.trim());
+    })
+    .map((item) => ({
+      name: item.name?.trim() as string,
+      chainId: item.chainId?.trim() as string,
+      bech32Prefix: item.bech32Prefix?.trim() || '',
+      endpointCount: item.endpointCount || 0,
+      rpcCount: item.rpcCount || 0,
+      restCount: item.restCount || 0,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
 export function normalizeBaseUrl(url: string): string {
   return url.trim().replace(/\/+$/, '');
 }
@@ -185,7 +224,15 @@ export function buildLookupUrl(options: LookupUrlOptions, requestPath: string): 
     };
   }
 
-  const directBaseUrl = normalizeBaseUrl(options.directRestBaseUrl || DEFAULT_DIRECT_REST_BASE_URL);
+  const explicitDirectBaseUrl = normalizeBaseUrl(options.directRestBaseUrl || '');
+  if (explicitDirectBaseUrl) {
+    return {
+      source,
+      url: `${explicitDirectBaseUrl}/${normalizedPath}`,
+    };
+  }
+
+  const directBaseUrl = normalizeBaseUrl(DEFAULT_DIRECT_REST_BASE_URL);
   return {
     source,
     url: `${directBaseUrl}/${encodeURIComponent(chainName)}/${normalizedPath}`,

--- a/web/index.html
+++ b/web/index.html
@@ -42,6 +42,7 @@
                 spellcheck="false"
                 required
               />
+              <small id="chain-summary-status" class="field-note">Loading registry chains</small>
             </label>
             <label>
               <span>Channel</span>
@@ -69,6 +70,17 @@
           </div>
 
           <input id="lazy-lb-base-url" name="lazyLbBaseUrl" type="hidden" />
+
+          <label id="direct-rest-field" class="wide-field" hidden>
+            <span>Direct REST endpoint</span>
+            <input
+              id="direct-rest-base-url"
+              name="directRestBaseUrl"
+              type="url"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </label>
 
           <div class="inline-options">
             <label class="check-row">

--- a/web/styles.css
+++ b/web/styles.css
@@ -180,6 +180,12 @@ label span {
   text-transform: uppercase;
 }
 
+.field-note {
+  color: var(--muted);
+  font: 0.7rem / 1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
+  overflow-wrap: anywhere;
+}
+
 input,
 select {
   width: 100%;


### PR DESCRIPTION
## Summary
- populate the chain selector from the hosted lazy-lb `/api/chains-summary` metadata endpoint
- show a direct REST endpoint field when Direct REST mode is selected
- use explicit direct REST endpoints exactly as entered and keep lookup traces visible
- document that registry metadata is for discovery while escrow, balance, and channel data come from live chain REST responses

## Validation
- `npm test`
- `npm run lint`
- `npm run build`
- browser check against `https://ibc-escrow.cac-group.io/`: loaded 238 registry chains, default lazy-lb lookup rendered `Balances (248)`, and direct REST mode used `https://rest.cosmos.directory/cosmoshub` for every lookup trace URL
- Caddy check: same-origin `/api/chains-summary` returns metadata, plain GET returns 404
