### PR TITLE
[codex] Fix chain picker and recents rail

### DIFF
--- a/web-src/app.ts
+++ b/web-src/app.ts
@@ -107,7 +107,7 @@ function byId<T extends HTMLElement>(id: string): T {
 }
 
 const form = byId<HTMLFormElement>('lookup-form');
-const chainInput = byId<HTMLInputElement>('chain-name');
+const chainInput = byId<HTMLSelectElement>('chain-name');
 const channelInput = byId<HTMLInputElement>('channel-id');
 const portInput = byId<HTMLInputElement>('port-id');
 const endpointModeInput = byId<HTMLSelectElement>('endpoint-mode');
@@ -129,8 +129,6 @@ const detailBody = byId<HTMLElement>('detail-body');
 const tracePanel = byId<HTMLElement>('trace-panel');
 const traceBody = byId<HTMLElement>('trace-body');
 const historyBody = byId<HTMLElement>('history-body');
-const chainOptions = byId<HTMLDataListElement>('chain-options');
-const chainSummaryStatus = byId<HTMLElement>('chain-summary-status');
 
 function loadSettings(): AppSettings {
   const defaults = getDefaultSettings();
@@ -279,13 +277,21 @@ function appendRequest(parent: HTMLElement, label: string, url: string): void {
 }
 
 function renderChainOptions(chains: ChainSummary[]): void {
-  clearNode(chainOptions);
+  const selectedChain = chainInput.value;
+  clearNode(chainInput);
 
   for (const chain of chains) {
     const option = document.createElement('option');
     option.value = chain.name;
-    option.label = `${chain.chainId} · REST ${chain.restCount} · RPC ${chain.rpcCount}`;
-    chainOptions.append(option);
+    option.textContent = chain.name;
+    option.dataset.chainId = chain.chainId;
+    option.dataset.restCount = String(chain.restCount);
+    option.dataset.rpcCount = String(chain.rpcCount);
+    chainInput.append(option);
+  }
+
+  if (selectedChain && chains.some((chain) => chain.name === selectedChain)) {
+    chainInput.value = selectedChain;
   }
 }
 
@@ -298,10 +304,8 @@ async function loadChainSummaries(): Promise<void> {
     }
 
     renderChainOptions(chains);
-    chainSummaryStatus.textContent = `${chains.length} registry chains`;
   } catch {
     renderChainOptions(FALLBACK_CHAINS);
-    chainSummaryStatus.textContent = 'Registry list unavailable';
   }
 }
 
@@ -461,6 +465,15 @@ async function runLookup(settings: AppSettings): Promise<void> {
   }
 
   renderEscrowResult(settings, escrowData.escrow_address, escrowRequest.source);
+  saveHistory({
+    chainName: settings.chainName,
+    channelId: settings.channelId,
+    portId: settings.portId,
+    escrowAddress: escrowData.escrow_address,
+    source: escrowRequest.source,
+    timestamp: Date.now(),
+  });
+  renderHistory();
 
   setStatus('Querying escrow balances', 'busy');
   const balances = await fetchAllBalances(options, escrowData.escrow_address, requests);
@@ -492,15 +505,6 @@ async function runLookup(settings: AppSettings): Promise<void> {
   }
 
   renderTrace(requests);
-  saveHistory({
-    chainName: settings.chainName,
-    channelId: settings.channelId,
-    portId: settings.portId,
-    escrowAddress: escrowData.escrow_address,
-    source: escrowRequest.source,
-    timestamp: Date.now(),
-  });
-  renderHistory();
   setStatus('Lookup complete', 'ok');
 }
 
@@ -536,19 +540,7 @@ resetButton.addEventListener('click', () => {
 });
 
 endpointModeInput.addEventListener('change', updateEndpointFields);
-chainInput.addEventListener('input', updateEndpointFields);
-
-document.querySelectorAll<HTMLButtonElement>('[data-preset]').forEach((button) => {
-  button.addEventListener('click', () => {
-    const [chainName, channelId] = (button.dataset.preset || '').split(':');
-    if (!chainName || !channelId) return;
-    chainInput.value = chainName;
-    channelInput.value = channelId;
-    portInput.value = 'transfer';
-    updateEndpointFields();
-    setStatus(`Loaded ${chainName} ${channelId}`, 'idle');
-  });
-});
+chainInput.addEventListener('change', updateEndpointFields);
 
 applySettings(loadSettings());
 void loadChainSummaries();

--- a/web/index.html
+++ b/web/index.html
@@ -34,15 +34,15 @@
           <div class="field-grid">
             <label>
               <span>Chain</span>
-              <input
+              <select
                 id="chain-name"
                 name="chain"
-                list="chain-options"
-                autocomplete="off"
-                spellcheck="false"
                 required
-              />
-              <small id="chain-summary-status" class="field-note">Loading registry chains</small>
+              >
+                <option value="cosmoshub">cosmoshub</option>
+                <option value="osmosis">osmosis</option>
+                <option value="noble">noble</option>
+              </select>
             </label>
             <label>
               <span>Channel</span>
@@ -93,28 +93,10 @@
             </div>
           </div>
 
-          <datalist id="chain-options">
-            <option value="cosmoshub"></option>
-            <option value="osmosis"></option>
-            <option value="neutron"></option>
-            <option value="noble"></option>
-            <option value="juno"></option>
-            <option value="stargaze"></option>
-            <option value="stride"></option>
-          </datalist>
         </form>
 
         <aside class="panel side-panel">
           <div class="panel-title">
-            <span>Presets</span>
-            <span class="panel-rule"></span>
-          </div>
-          <div class="preset-list">
-            <button type="button" data-preset="cosmoshub:channel-141">cosmoshub channel-141</button>
-            <button type="button" data-preset="osmosis:channel-0">osmosis channel-0</button>
-            <button type="button" data-preset="noble:channel-4">noble channel-4</button>
-          </div>
-          <div class="panel-title compact">
             <span>Recent</span>
             <span class="panel-rule"></span>
           </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -180,12 +180,6 @@ label span {
   text-transform: uppercase;
 }
 
-.field-note {
-  color: var(--muted);
-  font: 0.7rem / 1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
-  overflow-wrap: anywhere;
-}
-
 input,
 select {
   width: 100%;
@@ -237,7 +231,6 @@ select:focus {
 .primary-button,
 .secondary-button,
 .small-button,
-.preset-list button,
 .history-button {
   min-height: 38px;
   border: 1px solid var(--line-bright);
@@ -256,24 +249,21 @@ select:focus {
 
 .secondary-button:hover,
 .small-button:hover,
-.preset-list button:hover,
 .history-button:hover {
   border-color: var(--cyan);
   color: var(--cyan);
 }
 
 .side-panel {
-  min-height: 294px;
+  min-height: 0;
 }
 
-.preset-list,
 .history-list {
   display: grid;
   gap: 8px;
   padding: 12px 14px;
 }
 
-.preset-list button,
 .history-button {
   width: 100%;
   text-align: left;


### PR DESCRIPTION
## Summary
- replace the chain datalist input with a registry-populated select so opening Chain shows the full list instead of only the typed value
- remove the visible registry-count text and realign the top lookup controls
- remove Presets and keep the side panel as local browser Recent only
- save recent pairings immediately after escrow address resolution so the rail updates before slower optional detail calls finish

## Validation
- reproduced the old behavior in browser: `#chain-name` was `INPUT`, option count was `0`, side title was `Presets`, and 3 preset buttons were present
- `node --import tsx --test "web-src/**/*.test.ts"`
- `npm test`
- `npm run lint`
- `npm run build`
- browser check against `https://ibc-escrow.cac-group.io/`: Chain is `SELECT`, has 238 options, no `registry chains` text, no presets, Recent shows `cosmoshub channel-141`, persists after reload, and balances render as `Balances (248)`
