### PR TITLE
Add source and destination web lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,15 @@ yarn build:web
 ```
 
 Open `web/index.html` locally, or use the GitHub Pages deployment from this repository. The web UI supports:
-- escrow address lookup by chain, port, and channel
+- escrow address lookup by source chain and destination chain
+- automatic IBC channel resolution through the hosted Lazy-LB IBC-link API
+- optional channel and port override for manual lookups
 - escrow balance lookup through paginated bank balance requests
+- destination-chain voucher supply comparison for escrow balances
 - optional channel, connection, and client-state lookup sequence
 - registry-backed chain selection populated from the hosted Lazy-LB chain summary API
 - hosted Lazy-LB routing through `/lb/{chain}/{rest-path}` with no user-entered service URL
-- direct REST fallback through `https://rest.cosmos.directory/{chain}`, or an explicit chain-specific REST endpoint entered in the UI
+- direct REST fallback through `https://rest.cosmos.directory/{chain}`, or explicit source and destination REST endpoints entered in the UI
 
 ### Terminal UI
 ```bash

--- a/web-src/app.ts
+++ b/web-src/app.ts
@@ -6,8 +6,10 @@ import {
   buildChannelPath,
   buildClientStatePath,
   buildConnectionPath,
+  buildDestinationIbcDenom,
   buildEscrowAddressPath,
   buildLookupUrl,
+  buildSupplyByDenomPath,
   type ChainSummary,
   type ChannelDetails,
   type ChannelResponse,
@@ -17,19 +19,27 @@ import {
   extractClientId,
   extractConnectionId,
   getNextBalancePageKey,
+  type IbcLinksResponse,
   type LookupUrlOptions,
   normalizeBalances,
   normalizeBaseUrl,
+  normalizeChainSelection,
   normalizeChainSummaries,
+  normalizeSupplyAmount,
+  type ResolvedLookupRoute,
+  resolveLookupRoute,
+  type SupplyResponse,
 } from './lookup.js';
 
 interface AppSettings {
-  chainName: string;
+  sourceChainName: string;
+  destinationChainName: string;
   channelId: string;
   portId: string;
   endpointMode: EndpointMode;
   lazyLbBaseUrl: string;
-  directRestBaseUrl: string;
+  sourceDirectRestBaseUrl: string;
+  destinationDirectRestBaseUrl: string;
   includeDetails: boolean;
 }
 
@@ -38,7 +48,8 @@ interface EscrowAddressResponse {
 }
 
 interface HistoryEntry {
-  chainName: string;
+  sourceChainName: string;
+  destinationChainName: string;
   channelId: string;
   portId: string;
   escrowAddress: string;
@@ -46,9 +57,20 @@ interface HistoryEntry {
   timestamp: number;
 }
 
+interface SupplyComparisonRow {
+  denom: string;
+  amount: string;
+  destinationDenom: string;
+  destinationSupply: string;
+  delta: string;
+  error?: string;
+}
+
 const STORAGE_KEY = 'ibc-escrow-web-settings';
 const HISTORY_KEY = 'ibc-escrow-web-history';
 const HOSTED_LAZY_LB_BASE_URL = 'https://ibc-escrow.cac-group.io';
+const MAX_SUPPLY_COMPARISONS = 25;
+let chainSummaries: ChainSummary[] = [];
 const FALLBACK_CHAINS: ChainSummary[] = [
   {
     name: 'cosmoshub',
@@ -87,12 +109,14 @@ function getDefaultLazyLbBaseUrl(): string {
 
 function getDefaultSettings(): AppSettings {
   return {
-    chainName: 'cosmoshub',
-    channelId: 'channel-141',
+    sourceChainName: 'cosmoshub',
+    destinationChainName: 'osmosis',
+    channelId: '',
     portId: 'transfer',
     endpointMode: 'auto',
     lazyLbBaseUrl: getDefaultLazyLbBaseUrl(),
-    directRestBaseUrl: '',
+    sourceDirectRestBaseUrl: '',
+    destinationDirectRestBaseUrl: '',
     includeDetails: true,
   };
 }
@@ -107,13 +131,15 @@ function byId<T extends HTMLElement>(id: string): T {
 }
 
 const form = byId<HTMLFormElement>('lookup-form');
-const chainInput = byId<HTMLSelectElement>('chain-name');
+const sourceChainInput = byId<HTMLSelectElement>('source-chain-name');
+const destinationChainInput = byId<HTMLSelectElement>('destination-chain-name');
 const channelInput = byId<HTMLInputElement>('channel-id');
 const portInput = byId<HTMLInputElement>('port-id');
 const endpointModeInput = byId<HTMLSelectElement>('endpoint-mode');
 const lazyLbInput = byId<HTMLInputElement>('lazy-lb-base-url');
 const directRestField = byId<HTMLElement>('direct-rest-field');
-const directRestInput = byId<HTMLInputElement>('direct-rest-base-url');
+const sourceDirectRestInput = byId<HTMLInputElement>('source-direct-rest-base-url');
+const destinationDirectRestInput = byId<HTMLInputElement>('destination-direct-rest-base-url');
 const includeDetailsInput = byId<HTMLInputElement>('include-details');
 const submitButton = byId<HTMLButtonElement>('lookup-button');
 const resetButton = byId<HTMLButtonElement>('reset-button');
@@ -124,6 +150,9 @@ const resultBody = byId<HTMLElement>('result-body');
 const balancesPanel = byId<HTMLElement>('balances-panel');
 const balancesTitle = byId<HTMLElement>('balances-title');
 const balancesBody = byId<HTMLElement>('balances-body');
+const comparisonPanel = byId<HTMLElement>('comparison-panel');
+const comparisonTitle = byId<HTMLElement>('comparison-title');
+const comparisonBody = byId<HTMLElement>('comparison-body');
 const detailPanel = byId<HTMLElement>('detail-panel');
 const detailBody = byId<HTMLElement>('detail-body');
 const tracePanel = byId<HTMLElement>('trace-panel');
@@ -133,11 +162,22 @@ const historyBody = byId<HTMLElement>('history-body');
 function loadSettings(): AppSettings {
   const defaults = getDefaultSettings();
   try {
-    const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}') as Partial<AppSettings>;
+    const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}') as Partial<
+      AppSettings & {
+        chainName: string;
+        directRestBaseUrl: string;
+      }
+    >;
     return {
       ...defaults,
       ...parsed,
+      sourceChainName:
+        parsed.sourceChainName?.trim() || parsed.chainName?.trim() || defaults.sourceChainName,
+      destinationChainName: parsed.destinationChainName?.trim() || defaults.destinationChainName,
       lazyLbBaseUrl: parsed.lazyLbBaseUrl?.trim() || defaults.lazyLbBaseUrl,
+      sourceDirectRestBaseUrl:
+        parsed.sourceDirectRestBaseUrl?.trim() || parsed.directRestBaseUrl?.trim() || '',
+      destinationDirectRestBaseUrl: parsed.destinationDirectRestBaseUrl?.trim() || '',
     };
   } catch {
     return defaults;
@@ -149,24 +189,29 @@ function saveSettings(settings: AppSettings): void {
 }
 
 function readSettings(): AppSettings {
+  const chains = chainSummaries.length > 0 ? chainSummaries : FALLBACK_CHAINS;
   return {
-    chainName: chainInput.value.trim(),
+    sourceChainName: normalizeChainSelection(sourceChainInput.value.trim(), chains),
+    destinationChainName: normalizeChainSelection(destinationChainInput.value.trim(), chains),
     channelId: channelInput.value.trim(),
     portId: portInput.value.trim() || 'transfer',
     endpointMode: endpointModeInput.value as EndpointMode,
     lazyLbBaseUrl: lazyLbInput.value.trim(),
-    directRestBaseUrl: directRestInput.value.trim(),
+    sourceDirectRestBaseUrl: sourceDirectRestInput.value.trim(),
+    destinationDirectRestBaseUrl: destinationDirectRestInput.value.trim(),
     includeDetails: includeDetailsInput.checked,
   };
 }
 
 function applySettings(settings: AppSettings): void {
-  chainInput.value = settings.chainName;
+  sourceChainInput.value = settings.sourceChainName;
+  destinationChainInput.value = settings.destinationChainName;
   channelInput.value = settings.channelId;
   portInput.value = settings.portId;
   endpointModeInput.value = settings.endpointMode;
   lazyLbInput.value = settings.lazyLbBaseUrl;
-  directRestInput.value = settings.directRestBaseUrl;
+  sourceDirectRestInput.value = settings.sourceDirectRestBaseUrl;
+  destinationDirectRestInput.value = settings.destinationDirectRestBaseUrl;
   includeDetailsInput.checked = settings.includeDetails;
   updateEndpointFields();
 }
@@ -182,23 +227,33 @@ function setBusy(isBusy: boolean): void {
   form.toggleAttribute('aria-busy', isBusy);
 }
 
-function buildLookupOptions(settings: AppSettings): LookupUrlOptions {
+function buildLookupOptions(
+  settings: AppSettings,
+  chainName: string,
+  side: 'source' | 'destination'
+): LookupUrlOptions {
   return {
-    chainName: settings.chainName,
+    chainName,
     endpointMode: settings.endpointMode,
     lazyLbBaseUrl: settings.lazyLbBaseUrl || getDefaultLazyLbBaseUrl(),
-    directRestBaseUrl: settings.directRestBaseUrl,
+    directRestBaseUrl:
+      side === 'source' ? settings.sourceDirectRestBaseUrl : settings.destinationDirectRestBaseUrl,
   };
 }
 
-function getDefaultDirectRestBaseUrl(): string {
-  return `https://rest.cosmos.directory/${encodeURIComponent(chainInput.value.trim() || 'cosmoshub')}`;
+function getDefaultDirectRestBaseUrl(chainName: string): string {
+  return `https://rest.cosmos.directory/${encodeURIComponent(chainName.trim() || 'cosmoshub')}`;
 }
 
 function updateEndpointFields(): void {
   const directRestSelected = endpointModeInput.value === 'direct-rest';
   directRestField.hidden = !directRestSelected;
-  directRestInput.placeholder = getDefaultDirectRestBaseUrl();
+  sourceDirectRestInput.placeholder = getDefaultDirectRestBaseUrl(
+    sourceChainInput.value || 'cosmoshub'
+  );
+  destinationDirectRestInput.placeholder = getDefaultDirectRestBaseUrl(
+    destinationChainInput.value || 'osmosis'
+  );
 }
 
 function buildServiceUrl(path: string): string {
@@ -276,23 +331,42 @@ function appendRequest(parent: HTMLElement, label: string, url: string): void {
   parent.append(item);
 }
 
-function renderChainOptions(chains: ChainSummary[]): void {
-  const selectedChain = chainInput.value;
-  clearNode(chainInput);
+function appendChainOption(select: HTMLSelectElement, chain: ChainSummary): void {
+  const option = document.createElement('option');
+  option.value = chain.name;
+  option.textContent = `${chain.name} ${chain.chainId}`.trim();
+  option.dataset.chainId = chain.chainId;
+  option.dataset.restCount = String(chain.restCount);
+  option.dataset.rpcCount = String(chain.rpcCount);
+  select.append(option);
+}
+
+function renderChainSelect(
+  select: HTMLSelectElement,
+  chains: ChainSummary[],
+  fallback: string
+): void {
+  const selectedChain = select.value || fallback;
+  clearNode(select);
 
   for (const chain of chains) {
-    const option = document.createElement('option');
-    option.value = chain.name;
-    option.textContent = chain.name;
-    option.dataset.chainId = chain.chainId;
-    option.dataset.restCount = String(chain.restCount);
-    option.dataset.rpcCount = String(chain.rpcCount);
-    chainInput.append(option);
+    appendChainOption(select, chain);
   }
 
-  if (selectedChain && chains.some((chain) => chain.name === selectedChain)) {
-    chainInput.value = selectedChain;
+  if (!chains.some((chain) => chain.name === selectedChain)) {
+    const option = document.createElement('option');
+    option.value = selectedChain;
+    option.textContent = selectedChain;
+    select.prepend(option);
   }
+
+  select.value = selectedChain;
+}
+
+function renderChainOptions(chains: ChainSummary[]): void {
+  renderChainSelect(sourceChainInput, chains, 'cosmoshub');
+  renderChainSelect(destinationChainInput, chains, 'osmosis');
+  updateEndpointFields();
 }
 
 async function loadChainSummaries(): Promise<void> {
@@ -303,16 +377,31 @@ async function loadChainSummaries(): Promise<void> {
       throw new Error('No chain summaries returned');
     }
 
+    chainSummaries = chains;
     renderChainOptions(chains);
   } catch {
+    chainSummaries = FALLBACK_CHAINS;
     renderChainOptions(FALLBACK_CHAINS);
   }
 }
 
-function renderEscrowResult(settings: AppSettings, escrowAddress: string, source: string): void {
+function renderEscrowResult(
+  route: ResolvedLookupRoute,
+  escrowAddress: string,
+  source: string
+): void {
   clearNode(resultBody);
-  appendKeyValue(resultBody, 'Chain', settings.chainName);
-  appendKeyValue(resultBody, 'Port / channel', `${settings.portId}/${settings.channelId}`);
+  appendKeyValue(resultBody, 'Source chain', route.sourceChainName);
+  appendKeyValue(resultBody, 'Destination chain', route.destinationChainName);
+  appendKeyValue(resultBody, 'Port / channel', `${route.portId}/${route.channelId}`);
+  if (route.counterpartyChannelId) {
+    appendKeyValue(
+      resultBody,
+      'Counterparty channel',
+      `${route.counterpartyPortId}/${route.counterpartyChannelId}`
+    );
+  }
+  appendKeyValue(resultBody, 'Route source', route.source);
   appendKeyValue(resultBody, 'Escrow address', escrowAddress, true);
   appendKeyValue(resultBody, 'Source', source);
   resultPanel.hidden = false;
@@ -364,6 +453,64 @@ function renderBalances(balances: BalanceRow[]): void {
   balancesPanel.hidden = false;
 }
 
+function renderSupplyComparisons(rows: SupplyComparisonRow[], totalBalances: number): void {
+  clearNode(comparisonBody);
+  comparisonTitle.textContent = `Destination Supply (${rows.length})`;
+
+  if (rows.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-state';
+    empty.textContent = 'No escrow balances available for comparison';
+    comparisonBody.append(empty);
+    comparisonPanel.hidden = false;
+    return;
+  }
+
+  const header = document.createElement('div');
+  header.className = 'comparison-row comparison-head';
+  for (const label of ['Escrow', 'Denom', 'Supply', 'Delta']) {
+    const cell = document.createElement('span');
+    cell.textContent = label;
+    header.append(cell);
+  }
+  comparisonBody.append(header);
+
+  for (const row of rows) {
+    const item = document.createElement('div');
+    item.className = 'comparison-row';
+
+    const sourceAmount = document.createElement('span');
+    sourceAmount.className = 'comparison-amount';
+    sourceAmount.textContent = row.amount;
+
+    const denom = document.createElement('span');
+    denom.className = 'comparison-denom';
+    denom.textContent = row.destinationDenom
+      ? `${row.denom} -> ${row.destinationDenom}`
+      : row.denom;
+
+    const destinationSupply = document.createElement('span');
+    destinationSupply.className = row.error ? 'comparison-error' : 'comparison-amount';
+    destinationSupply.textContent = row.error || row.destinationSupply;
+
+    const delta = document.createElement('span');
+    delta.className = row.delta === '0' ? 'comparison-ok' : 'comparison-delta';
+    delta.textContent = row.error ? '-' : row.delta;
+
+    item.append(sourceAmount, denom, destinationSupply, delta);
+    comparisonBody.append(item);
+  }
+
+  if (totalBalances > rows.length) {
+    const capped = document.createElement('p');
+    capped.className = 'empty-state';
+    capped.textContent = `${totalBalances - rows.length} additional balances not compared`;
+    comparisonBody.append(capped);
+  }
+
+  comparisonPanel.hidden = false;
+}
+
 async function fetchAllBalances(
   options: LookupUrlOptions,
   escrowAddress: string,
@@ -393,6 +540,57 @@ async function fetchAllBalances(
   throw new Error('Balance lookup exceeded pagination limit');
 }
 
+function subtractAmounts(left: string, right: string): string {
+  try {
+    return (BigInt(left) - BigInt(right)).toString();
+  } catch {
+    return '';
+  }
+}
+
+async function fetchSupplyComparisons(
+  options: LookupUrlOptions,
+  route: ResolvedLookupRoute,
+  balances: BalanceRow[],
+  requests: Array<{ label: string; url: string }>
+): Promise<SupplyComparisonRow[]> {
+  const comparableBalances = balances
+    .filter((balance) => balance.amount !== '0')
+    .slice(0, MAX_SUPPLY_COMPARISONS);
+  const rows: SupplyComparisonRow[] = [];
+
+  for (const [index, balance] of comparableBalances.entries()) {
+    try {
+      const destinationDenom = await buildDestinationIbcDenom(route, balance.denom);
+      const supplyRequest = buildLookupUrl(options, buildSupplyByDenomPath(destinationDenom));
+      requests.push({
+        label: `supply ${index + 1}`,
+        url: supplyRequest.url,
+      });
+      const supplyData = (await fetchJson(supplyRequest.url)) as SupplyResponse;
+      const destinationSupply = normalizeSupplyAmount(supplyData);
+      rows.push({
+        denom: balance.denom,
+        amount: balance.amount,
+        destinationDenom,
+        destinationSupply,
+        delta: subtractAmounts(balance.amount, destinationSupply),
+      });
+    } catch (error) {
+      rows.push({
+        denom: balance.denom,
+        amount: balance.amount,
+        destinationDenom: '',
+        destinationSupply: '0',
+        delta: '',
+        error: error instanceof Error ? error.message : 'Supply lookup failed',
+      });
+    }
+  }
+
+  return rows;
+}
+
 function renderTrace(requests: Array<{ label: string; url: string }>): void {
   clearNode(traceBody);
   for (const request of requests) {
@@ -403,8 +601,21 @@ function renderTrace(requests: Array<{ label: string; url: string }>): void {
 
 function loadHistory(): HistoryEntry[] {
   try {
-    const parsed = JSON.parse(localStorage.getItem(HISTORY_KEY) || '[]') as HistoryEntry[];
-    return Array.isArray(parsed) ? parsed.slice(0, 6) : [];
+    const parsed = JSON.parse(localStorage.getItem(HISTORY_KEY) || '[]') as Array<
+      HistoryEntry & {
+        chainName?: string;
+      }
+    >;
+    return Array.isArray(parsed)
+      ? parsed
+          .map((item) => ({
+            ...item,
+            sourceChainName: item.sourceChainName || item.chainName || '',
+            destinationChainName: item.destinationChainName || '',
+          }))
+          .filter((item) => item.sourceChainName && item.channelId)
+          .slice(0, 6)
+      : [];
   } catch {
     return [];
   }
@@ -414,7 +625,8 @@ function saveHistory(entry: HistoryEntry): void {
   const history = loadHistory().filter(
     (item) =>
       !(
-        item.chainName === entry.chainName &&
+        item.sourceChainName === entry.sourceChainName &&
+        item.destinationChainName === entry.destinationChainName &&
         item.channelId === entry.channelId &&
         item.portId === entry.portId
       )
@@ -438,25 +650,68 @@ function renderHistory(): void {
     const button = document.createElement('button');
     button.type = 'button';
     button.className = 'history-button';
-    button.textContent = `${item.chainName} ${item.channelId}`;
+    button.textContent = `${item.sourceChainName} -> ${item.destinationChainName || '?'} ${item.channelId}`;
     button.addEventListener('click', () => {
-      chainInput.value = item.chainName;
+      sourceChainInput.value = item.sourceChainName;
+      if (item.destinationChainName) {
+        destinationChainInput.value = item.destinationChainName;
+      }
       channelInput.value = item.channelId;
       portInput.value = item.portId;
       updateEndpointFields();
-      setStatus(`Loaded ${item.chainName} ${item.channelId}`, 'idle');
+      setStatus(`Loaded ${item.sourceChainName} ${item.channelId}`, 'idle');
     });
     historyBody.append(button);
   }
 }
 
+async function resolveRouteForLookup(
+  settings: AppSettings,
+  requests: Array<{ label: string; url: string }>
+): Promise<ResolvedLookupRoute> {
+  if (settings.channelId.trim()) {
+    return resolveLookupRoute({
+      sourceChainName: settings.sourceChainName,
+      destinationChainName: settings.destinationChainName,
+      channelId: settings.channelId,
+      portId: settings.portId,
+    });
+  }
+
+  const query = new URLSearchParams({
+    source: settings.sourceChainName,
+    destination: settings.destinationChainName,
+  });
+  const url = buildServiceUrl(`/api/ibc-links?${query.toString()}`);
+  requests.push({ label: 'ibc links', url });
+  const response = (await fetchJson(url)) as IbcLinksResponse;
+
+  return resolveLookupRoute(
+    {
+      sourceChainName: settings.sourceChainName,
+      destinationChainName: settings.destinationChainName,
+      channelId: settings.channelId,
+      portId: settings.portId,
+    },
+    response
+  );
+}
+
 async function runLookup(settings: AppSettings): Promise<void> {
-  const options = buildLookupOptions(settings);
   const requests: Array<{ label: string; url: string }> = [];
 
+  setStatus('Resolving route', 'busy');
+  const route = await resolveRouteForLookup(settings, requests);
+  const sourceOptions = buildLookupOptions(settings, route.sourceChainName, 'source');
+  const destinationOptions = buildLookupOptions(
+    settings,
+    route.destinationChainName,
+    'destination'
+  );
+
   setStatus('Querying escrow address', 'busy');
-  const escrowPath = buildEscrowAddressPath(settings.channelId, settings.portId);
-  const escrowRequest = buildLookupUrl(options, escrowPath);
+  const escrowPath = buildEscrowAddressPath(route.channelId, route.portId);
+  const escrowRequest = buildLookupUrl(sourceOptions, escrowPath);
   requests.push({ label: 'escrow', url: escrowRequest.url });
   const escrowData = (await fetchJson(escrowRequest.url)) as EscrowAddressResponse;
 
@@ -464,11 +719,12 @@ async function runLookup(settings: AppSettings): Promise<void> {
     throw new Error('Escrow address was not returned');
   }
 
-  renderEscrowResult(settings, escrowData.escrow_address, escrowRequest.source);
+  renderEscrowResult(route, escrowData.escrow_address, escrowRequest.source);
   saveHistory({
-    chainName: settings.chainName,
-    channelId: settings.channelId,
-    portId: settings.portId,
+    sourceChainName: route.sourceChainName,
+    destinationChainName: route.destinationChainName,
+    channelId: route.channelId,
+    portId: route.portId,
     escrowAddress: escrowData.escrow_address,
     source: escrowRequest.source,
     timestamp: Date.now(),
@@ -476,25 +732,29 @@ async function runLookup(settings: AppSettings): Promise<void> {
   renderHistory();
 
   setStatus('Querying escrow balances', 'busy');
-  const balances = await fetchAllBalances(options, escrowData.escrow_address, requests);
+  const balances = await fetchAllBalances(sourceOptions, escrowData.escrow_address, requests);
   renderBalances(balances);
+
+  setStatus('Comparing destination supply', 'busy');
+  const comparisons = await fetchSupplyComparisons(destinationOptions, route, balances, requests);
+  renderSupplyComparisons(comparisons, balances.filter((balance) => balance.amount !== '0').length);
 
   if (settings.includeDetails) {
     setStatus('Querying channel details', 'busy');
     const channelRequest = buildLookupUrl(
-      options,
-      buildChannelPath(settings.channelId, settings.portId)
+      sourceOptions,
+      buildChannelPath(route.channelId, route.portId)
     );
     requests.push({ label: 'channel', url: channelRequest.url });
     const channelData = (await fetchJson(channelRequest.url)) as ChannelResponse;
     const connectionId = extractConnectionId(channelData);
 
-    const connectionRequest = buildLookupUrl(options, buildConnectionPath(connectionId));
+    const connectionRequest = buildLookupUrl(sourceOptions, buildConnectionPath(connectionId));
     requests.push({ label: 'connection', url: connectionRequest.url });
     const connectionData = (await fetchJson(connectionRequest.url)) as ConnectionResponse;
     const clientId = extractClientId(connectionData);
 
-    const clientRequest = buildLookupUrl(options, buildClientStatePath(clientId));
+    const clientRequest = buildLookupUrl(sourceOptions, buildClientStatePath(clientId));
     requests.push({ label: 'client', url: clientRequest.url });
     const clientStateData = (await fetchJson(clientRequest.url)) as ClientStateResponse;
 
@@ -530,17 +790,21 @@ resetButton.addEventListener('click', () => {
   clearNode(resultBody);
   clearNode(balancesBody);
   balancesTitle.textContent = 'Balances';
+  clearNode(comparisonBody);
+  comparisonTitle.textContent = 'Destination Supply';
   clearNode(detailBody);
   clearNode(traceBody);
   resultPanel.hidden = true;
   balancesPanel.hidden = true;
+  comparisonPanel.hidden = true;
   detailPanel.hidden = true;
   tracePanel.hidden = true;
   setStatus('Ready', 'idle');
 });
 
 endpointModeInput.addEventListener('change', updateEndpointFields);
-chainInput.addEventListener('change', updateEndpointFields);
+sourceChainInput.addEventListener('change', updateEndpointFields);
+destinationChainInput.addEventListener('change', updateEndpointFields);
 
 applySettings(loadSettings());
 void loadChainSummaries();

--- a/web-src/lookup.test.ts
+++ b/web-src/lookup.test.ts
@@ -6,11 +6,17 @@ import {
   buildChannelPath,
   buildClientStatePath,
   buildConnectionPath,
+  buildDestinationIbcDenom,
   buildEscrowAddressPath,
+  buildIbcDenom,
   buildLookupUrl,
+  buildSupplyByDenomPath,
   getNextBalancePageKey,
   normalizeBalances,
+  normalizeChainSelection,
   normalizeChainSummaries,
+  normalizeSupplyAmount,
+  resolveLookupRoute,
   resolveRequestSource,
 } from './lookup.ts';
 
@@ -158,6 +164,160 @@ describe('web lookup helpers', () => {
     );
 
     assert.deepEqual(normalizeChainSummaries({}), []);
+  });
+
+  it('resolves chain selections by name or chain ID', () => {
+    const chains = normalizeChainSummaries([
+      {
+        name: 'genesisl1',
+        chainId: 'genesis_29-2',
+        bech32Prefix: 'genesis',
+      },
+      {
+        name: 'osmosis',
+        chainId: 'osmosis-1',
+        bech32Prefix: 'osmo',
+      },
+    ]);
+
+    assert.equal(normalizeChainSelection('genesisl1', chains), 'genesisl1');
+    assert.equal(normalizeChainSelection('GENESIS_29-2', chains), 'genesisl1');
+    assert.equal(normalizeChainSelection('osmosis-1', chains), 'osmosis');
+    assert.throws(() => normalizeChainSelection('missing-1', chains), /Unknown chain/);
+  });
+
+  it('resolves lookup routes from transfer registry links unless a manual channel override is supplied', () => {
+    assert.deepEqual(
+      resolveLookupRoute(
+        {
+          sourceChainName: 'genesisl1',
+          destinationChainName: 'osmosis',
+          channelId: '',
+          portId: '',
+        },
+        {
+          source: { name: 'genesisl1', chainId: 'genesis_29-2' },
+          destination: { name: 'osmosis', chainId: 'osmosis-1' },
+          links: [
+            {
+              sourceChainName: 'genesisl1',
+              sourceChainId: 'genesis_29-2',
+              destinationChainName: 'osmosis',
+              destinationChainId: 'osmosis-1',
+              channelId: 'channel-8',
+              portId: 'provider',
+              counterpartyChannelId: 'channel-508',
+              counterpartyPortId: 'consumer',
+              clientId: '07-tendermint-2',
+              counterpartyClientId: '07-tendermint-1984',
+              connectionId: 'connection-2',
+              counterpartyConnectionId: 'connection-1540',
+              ordering: 'ordered',
+              version: 'ics20-1',
+              tags: { preferred: true, status: 'live' },
+              sourceFile: 'genesisl1-osmosis.json',
+            },
+            {
+              sourceChainName: 'genesisl1',
+              sourceChainId: 'genesis_29-2',
+              destinationChainName: 'osmosis',
+              destinationChainId: 'osmosis-1',
+              channelId: 'channel-1',
+              portId: 'transfer',
+              counterpartyChannelId: 'channel-253',
+              counterpartyPortId: 'transfer',
+              clientId: '07-tendermint-1',
+              counterpartyClientId: '07-tendermint-1983',
+              connectionId: 'connection-1',
+              counterpartyConnectionId: 'connection-1539',
+              ordering: 'unordered',
+              version: 'ics20-1',
+              tags: { preferred: true, status: 'live' },
+              sourceFile: 'genesisl1-osmosis.json',
+            },
+          ],
+        }
+      ),
+      {
+        sourceChainName: 'genesisl1',
+        destinationChainName: 'osmosis',
+        channelId: 'channel-1',
+        portId: 'transfer',
+        counterpartyChannelId: 'channel-253',
+        counterpartyPortId: 'transfer',
+        source: 'registry',
+      }
+    );
+
+    assert.deepEqual(
+      resolveLookupRoute({
+        sourceChainName: 'genesisl1',
+        destinationChainName: 'osmosis',
+        channelId: 'channel-99',
+        portId: 'custom',
+      }),
+      {
+        sourceChainName: 'genesisl1',
+        destinationChainName: 'osmosis',
+        channelId: 'channel-99',
+        portId: 'custom',
+        counterpartyChannelId: '',
+        counterpartyPortId: '',
+        source: 'manual',
+      }
+    );
+  });
+
+  it('builds destination supply paths and hashes denoms with destination-side IBC paths', async () => {
+    assert.equal(
+      buildSupplyByDenomPath('ibc/ABC'),
+      '/cosmos/bank/v1beta1/supply/by_denom?denom=ibc%2FABC'
+    );
+    assert.equal(
+      await buildIbcDenom('transfer', 'channel-1', 'el1'),
+      'ibc/776644F2A446095B20E741B2CD25F3E50E4672CD3CC01230D987AA23A95F4B87'
+    );
+    assert.equal(
+      await buildDestinationIbcDenom(
+        {
+          sourceChainName: 'cosmoshub',
+          destinationChainName: 'osmosis',
+          channelId: 'channel-141',
+          portId: 'transfer',
+          counterpartyChannelId: 'channel-0',
+          counterpartyPortId: 'transfer',
+          source: 'registry',
+        },
+        'uatom'
+      ),
+      'ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2'
+    );
+    await assert.rejects(
+      () =>
+        buildDestinationIbcDenom(
+          {
+            sourceChainName: 'cosmoshub',
+            destinationChainName: 'osmosis',
+            channelId: 'channel-141',
+            portId: 'transfer',
+            counterpartyChannelId: '',
+            counterpartyPortId: '',
+            source: 'manual',
+          },
+          'uatom'
+        ),
+      /Counterparty channel is required/
+    );
+    assert.equal(
+      normalizeSupplyAmount({
+        amount: {
+          denom: 'ibc/ABC',
+          amount: '123',
+        },
+      }),
+      '123'
+    );
+    assert.equal(normalizeSupplyAmount({}), '0');
   });
 
   it('builds dependent channel detail requests and summary data', () => {

--- a/web-src/lookup.ts
+++ b/web-src/lookup.ts
@@ -39,6 +39,59 @@ export interface ChainSummary {
   restCount: number;
 }
 
+export interface IbcLink {
+  sourceChainName: string;
+  sourceChainId: string;
+  destinationChainName: string;
+  destinationChainId: string;
+  channelId: string;
+  portId: string;
+  counterpartyChannelId: string;
+  counterpartyPortId: string;
+  clientId: string;
+  counterpartyClientId: string;
+  connectionId: string;
+  counterpartyConnectionId: string;
+  ordering: string;
+  version: string;
+  tags: {
+    status?: string;
+    preferred?: boolean;
+    dex?: string;
+    properties?: string;
+  };
+  sourceFile: string;
+}
+
+export interface IbcLinksResponse {
+  source: {
+    name: string;
+    chainId: string;
+  };
+  destination: {
+    name: string;
+    chainId: string;
+  };
+  links: IbcLink[];
+}
+
+export interface LookupRouteInput {
+  sourceChainName: string;
+  destinationChainName: string;
+  channelId?: string;
+  portId?: string;
+}
+
+export interface ResolvedLookupRoute {
+  sourceChainName: string;
+  destinationChainName: string;
+  channelId: string;
+  portId: string;
+  counterpartyChannelId: string;
+  counterpartyPortId: string;
+  source: 'registry' | 'manual';
+}
+
 interface ChainSummaryResponseItem {
   name?: string;
   chainId?: string;
@@ -56,6 +109,13 @@ export interface BalancesResponse {
   pagination?: {
     next_key?: string | null;
     total?: string;
+  };
+}
+
+export interface SupplyResponse {
+  amount?: {
+    denom?: string;
+    amount?: string;
   };
 }
 
@@ -153,6 +213,16 @@ export function buildBalancesPath(address: string, paginationKey?: string): stri
   return `${path}?${query.toString()}`;
 }
 
+export function buildSupplyByDenomPath(denom: string): string {
+  const cleanDenom = denom.trim();
+  if (!cleanDenom) {
+    throw new Error('Denom is required');
+  }
+
+  const query = new URLSearchParams({ denom: cleanDenom });
+  return `/cosmos/bank/v1beta1/supply/by_denom?${query.toString()}`;
+}
+
 export function normalizeBalances(response: BalancesResponse): BalanceRow[] {
   return (response.balances || [])
     .filter((balance) => balance.denom && balance.amount)
@@ -160,6 +230,10 @@ export function normalizeBalances(response: BalancesResponse): BalanceRow[] {
       denom: balance.denom as string,
       amount: balance.amount as string,
     }));
+}
+
+export function normalizeSupplyAmount(response: SupplyResponse): string {
+  return response.amount?.amount || '0';
 }
 
 export function getNextBalancePageKey(response: BalancesResponse): string | undefined {
@@ -185,6 +259,104 @@ export function normalizeChainSummaries(response: unknown): ChainSummary[] {
       restCount: item.restCount || 0,
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function normalizeChainSelection(input: string, chains: ChainSummary[]): string {
+  const normalizedInput = input.trim().toLowerCase();
+  const chain = chains.find(
+    (candidate) =>
+      candidate.name.toLowerCase() === normalizedInput ||
+      candidate.chainId.toLowerCase() === normalizedInput
+  );
+
+  if (!chain) {
+    throw new Error(`Unknown chain: ${input}`);
+  }
+
+  return chain.name;
+}
+
+export function resolveLookupRoute(
+  input: LookupRouteInput,
+  linksResponse?: IbcLinksResponse
+): ResolvedLookupRoute {
+  const manualChannelId = input.channelId?.trim() || '';
+  const portId = input.portId?.trim() || 'transfer';
+
+  if (manualChannelId) {
+    validateChannelId(manualChannelId);
+    validatePortId(portId);
+    return {
+      sourceChainName: input.sourceChainName,
+      destinationChainName: input.destinationChainName,
+      channelId: manualChannelId,
+      portId,
+      counterpartyChannelId: '',
+      counterpartyPortId: '',
+      source: 'manual',
+    };
+  }
+
+  const link = linksResponse?.links.find(
+    (candidate) => candidate.portId === 'transfer' && candidate.counterpartyPortId === 'transfer'
+  );
+  if (!link) {
+    throw new Error(
+      `No transfer IBC channel link found for ${input.sourceChainName} to ${input.destinationChainName}`
+    );
+  }
+
+  return {
+    sourceChainName: link.sourceChainName,
+    destinationChainName: link.destinationChainName,
+    channelId: link.channelId,
+    portId: link.portId || 'transfer',
+    counterpartyChannelId: link.counterpartyChannelId,
+    counterpartyPortId: link.counterpartyPortId,
+    source: 'registry',
+  };
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+    .toUpperCase();
+}
+
+export async function buildIbcDenom(
+  portId: string,
+  channelId: string,
+  baseDenom: string
+): Promise<string> {
+  validatePortId(portId);
+  validateChannelId(channelId);
+  const cleanBaseDenom = baseDenom.trim();
+  if (!cleanBaseDenom) {
+    throw new Error('Base denom is required');
+  }
+
+  const cryptoApi = globalThis.crypto?.subtle;
+  if (!cryptoApi) {
+    throw new Error('Web Crypto API is required to hash IBC denoms');
+  }
+
+  const payload = new TextEncoder().encode(
+    `${portId.trim()}/${channelId.trim()}/${cleanBaseDenom}`
+  );
+  const digest = await cryptoApi.digest('SHA-256', payload);
+  return `ibc/${bytesToHex(new Uint8Array(digest))}`;
+}
+
+export async function buildDestinationIbcDenom(
+  route: ResolvedLookupRoute,
+  baseDenom: string
+): Promise<string> {
+  if (!route.counterpartyPortId || !route.counterpartyChannelId) {
+    throw new Error('Counterparty channel is required to compare destination supply');
+  }
+
+  return buildIbcDenom(route.counterpartyPortId, route.counterpartyChannelId, baseDenom);
 }
 
 export function normalizeBaseUrl(url: string): string {

--- a/web/index.html
+++ b/web/index.html
@@ -33,31 +33,28 @@
 
           <div class="field-grid">
             <label>
-              <span>Chain</span>
+              <span>Source chain</span>
               <select
-                id="chain-name"
-                name="chain"
+                id="source-chain-name"
+                name="sourceChain"
                 required
               >
-                <option value="cosmoshub">cosmoshub</option>
-                <option value="osmosis">osmosis</option>
-                <option value="noble">noble</option>
+                <option value="cosmoshub">cosmoshub cosmoshub-4</option>
+                <option value="osmosis">osmosis osmosis-1</option>
+                <option value="noble">noble noble-1</option>
               </select>
             </label>
             <label>
-              <span>Channel</span>
-              <input
-                id="channel-id"
-                name="channel"
-                pattern="channel-[0-9]+"
-                autocomplete="off"
-                spellcheck="false"
+              <span>Destination chain</span>
+              <select
+                id="destination-chain-name"
+                name="destinationChain"
                 required
-              />
-            </label>
-            <label>
-              <span>Port</span>
-              <input id="port-id" name="port" autocomplete="off" spellcheck="false" required />
+              >
+                <option value="osmosis">osmosis osmosis-1</option>
+                <option value="cosmoshub">cosmoshub cosmoshub-4</option>
+                <option value="noble">noble noble-1</option>
+              </select>
             </label>
             <label>
               <span>Endpoint</span>
@@ -69,18 +66,47 @@
             </label>
           </div>
 
+          <div class="field-grid secondary-grid">
+            <label>
+              <span>Channel override</span>
+              <input
+                id="channel-id"
+                name="channel"
+                pattern="channel-[0-9]+"
+                autocomplete="off"
+                spellcheck="false"
+              />
+            </label>
+            <label>
+              <span>Port</span>
+              <input id="port-id" name="port" autocomplete="off" spellcheck="false" />
+            </label>
+          </div>
+
           <input id="lazy-lb-base-url" name="lazyLbBaseUrl" type="hidden" />
 
-          <label id="direct-rest-field" class="wide-field" hidden>
-            <span>Direct REST endpoint</span>
-            <input
-              id="direct-rest-base-url"
-              name="directRestBaseUrl"
-              type="url"
-              autocomplete="off"
-              spellcheck="false"
-            />
-          </label>
+          <div id="direct-rest-field" class="field-grid direct-grid" hidden>
+            <label>
+              <span>Source REST endpoint</span>
+              <input
+                id="source-direct-rest-base-url"
+                name="sourceDirectRestBaseUrl"
+                type="url"
+                autocomplete="off"
+                spellcheck="false"
+              />
+            </label>
+            <label>
+              <span>Destination REST endpoint</span>
+              <input
+                id="destination-direct-rest-base-url"
+                name="destinationDirectRestBaseUrl"
+                type="url"
+                autocomplete="off"
+                spellcheck="false"
+              />
+            </label>
+          </div>
 
           <div class="inline-options">
             <label class="check-row">
@@ -127,6 +153,14 @@
             <span class="panel-rule"></span>
           </div>
           <div id="balances-body" class="balance-list"></div>
+        </article>
+
+        <article id="comparison-panel" class="panel trace-panel" hidden>
+          <div class="panel-title">
+            <span id="comparison-title">Destination Supply</span>
+            <span class="panel-rule"></span>
+          </div>
+          <div id="comparison-body" class="comparison-list"></div>
         </article>
 
         <article id="trace-panel" class="panel trace-panel" hidden>

--- a/web/styles.css
+++ b/web/styles.css
@@ -163,9 +163,20 @@ h1 {
 
 .field-grid {
   display: grid;
-  grid-template-columns: 1.1fr 1fr 0.8fr 0.9fr;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1.1fr) minmax(180px, 0.7fr);
   gap: 12px;
   padding: 14px;
+}
+
+.secondary-grid {
+  grid-template-columns: minmax(180px, 0.5fr) minmax(140px, 0.35fr) minmax(0, 1fr);
+  padding-top: 0;
+}
+
+.direct-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  padding-top: 0;
+  padding-bottom: 14px;
 }
 
 label {
@@ -282,7 +293,8 @@ select:focus {
 
 .kv-list,
 .trace-list,
-.balance-list {
+.balance-list,
+.comparison-list {
   display: grid;
   gap: 0;
   padding: 4px 14px 14px;
@@ -326,15 +338,59 @@ select:focus {
   border-bottom: 1px solid rgba(104, 135, 101, 0.22);
 }
 
+.comparison-row {
+  display: grid;
+  grid-template-columns:
+    minmax(120px, 0.18fr) minmax(180px, 0.32fr) minmax(120px, 0.18fr)
+    minmax(120px, 0.18fr);
+  gap: 14px;
+  align-items: start;
+  min-height: 42px;
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(104, 135, 101, 0.22);
+}
+
+.comparison-head {
+  min-height: 28px;
+  color: var(--muted);
+  font: 700 0.72rem / 1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-transform: uppercase;
+}
+
 .balance-amount {
   color: var(--green);
   font: 0.92rem / 1.35 ui-monospace, SFMono-Regular, Menlo, monospace;
   overflow-wrap: anywhere;
 }
 
+.comparison-amount,
+.comparison-ok {
+  color: var(--green);
+  font: 0.88rem / 1.35 ui-monospace, SFMono-Regular, Menlo, monospace;
+  overflow-wrap: anywhere;
+}
+
 .balance-denom {
   color: var(--text);
   font: 0.88rem / 1.35 ui-monospace, SFMono-Regular, Menlo, monospace;
+  overflow-wrap: anywhere;
+}
+
+.comparison-denom {
+  color: var(--text);
+  font: 0.82rem / 1.35 ui-monospace, SFMono-Regular, Menlo, monospace;
+  overflow-wrap: anywhere;
+}
+
+.comparison-delta {
+  color: var(--amber);
+  font: 0.88rem / 1.35 ui-monospace, SFMono-Regular, Menlo, monospace;
+  overflow-wrap: anywhere;
+}
+
+.comparison-error {
+  color: var(--red);
+  font: 0.8rem / 1.35 ui-monospace, SFMono-Regular, Menlo, monospace;
   overflow-wrap: anywhere;
 }
 
@@ -365,6 +421,11 @@ select:focus {
   .field-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .secondary-grid,
+  .direct-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 620px) {
@@ -392,7 +453,8 @@ select:focus {
 
   .kv-row,
   .trace-row,
-  .balance-row {
+  .balance-row,
+  .comparison-row {
     grid-template-columns: 1fr;
     gap: 5px;
     padding: 10px 0;


### PR DESCRIPTION
## Summary
- make Source chain and Destination chain the primary web lookup fields
- resolve IBC transfer channels through the hosted lazy-lb IBC-link API, while keeping channel/port as optional manual overrides
- compare source escrow balances to destination voucher supply using the destination-side counterparty channel

## Verification
- npm run lint
- npm test
- npm run build
- second-pass explorer review: no blocking issues