### PR TITLE
Add chain metadata loading indicator

### DIFF
--- a/web-src/app.ts
+++ b/web-src/app.ts
@@ -18,6 +18,7 @@ import {
   type EndpointMode,
   extractClientId,
   extractConnectionId,
+  getChainMetadataFeedback,
   getNextBalancePageKey,
   type IbcLinksResponse,
   type LookupUrlOptions,
@@ -28,6 +29,7 @@ import {
   normalizeSupplyAmount,
   type ResolvedLookupRoute,
   resolveLookupRoute,
+  type StatusState,
   type SupplyResponse,
 } from './lookup.js';
 
@@ -71,6 +73,9 @@ const HISTORY_KEY = 'ibc-escrow-web-history';
 const HOSTED_LAZY_LB_BASE_URL = 'https://ibc-escrow.cac-group.io';
 const MAX_SUPPLY_COMPARISONS = 25;
 let chainSummaries: ChainSummary[] = [];
+let lookupBusy = false;
+let chainControlsDisabled = true;
+let lookupDisabledForChains = true;
 const FALLBACK_CHAINS: ChainSummary[] = [
   {
     name: 'cosmoshub',
@@ -140,6 +145,7 @@ const lazyLbInput = byId<HTMLInputElement>('lazy-lb-base-url');
 const directRestField = byId<HTMLElement>('direct-rest-field');
 const sourceDirectRestInput = byId<HTMLInputElement>('source-direct-rest-base-url');
 const destinationDirectRestInput = byId<HTMLInputElement>('destination-direct-rest-base-url');
+const chainListNote = byId<HTMLElement>('chain-list-note');
 const includeDetailsInput = byId<HTMLInputElement>('include-details');
 const submitButton = byId<HTMLButtonElement>('lookup-button');
 const resetButton = byId<HTMLButtonElement>('reset-button');
@@ -216,15 +222,34 @@ function applySettings(settings: AppSettings): void {
   updateEndpointFields();
 }
 
-function setStatus(message: string, state: 'idle' | 'busy' | 'ok' | 'error' = 'idle'): void {
+function setStatus(message: string, state: StatusState = 'idle'): void {
   statusText.textContent = message;
   statusDot.dataset.state = state;
 }
 
+function updateControlState(): void {
+  const chainsUnavailable = chainControlsDisabled || lookupDisabledForChains;
+  submitButton.disabled = lookupBusy || lookupDisabledForChains;
+  resetButton.disabled = lookupBusy;
+  sourceChainInput.disabled = lookupBusy || chainControlsDisabled;
+  destinationChainInput.disabled = lookupBusy || chainControlsDisabled;
+  form.toggleAttribute('aria-busy', lookupBusy || chainsUnavailable);
+}
+
 function setBusy(isBusy: boolean): void {
-  submitButton.disabled = isBusy;
-  resetButton.disabled = isBusy;
-  form.toggleAttribute('aria-busy', isBusy);
+  lookupBusy = isBusy;
+  updateControlState();
+}
+
+function setChainMetadataState(state: 'loading' | 'ready' | 'fallback'): void {
+  const feedback = getChainMetadataFeedback(state);
+  chainControlsDisabled = feedback.chainControlsDisabled;
+  lookupDisabledForChains = feedback.lookupDisabled;
+  chainListNote.textContent = feedback.note;
+  chainListNote.hidden = !feedback.note;
+  chainListNote.dataset.state = state;
+  setStatus(feedback.statusMessage, feedback.statusState);
+  updateControlState();
 }
 
 function buildLookupOptions(
@@ -341,6 +366,31 @@ function appendChainOption(select: HTMLSelectElement, chain: ChainSummary): void
   select.append(option);
 }
 
+function renderChainLoadingSelect(
+  select: HTMLSelectElement,
+  selectedValue: string,
+  placeholderText: string
+): void {
+  clearNode(select);
+  const option = document.createElement('option');
+  option.value = selectedValue;
+  option.textContent = placeholderText;
+  option.disabled = true;
+  select.append(option);
+  select.value = selectedValue;
+}
+
+function renderChainLoadingOptions(settings: AppSettings): void {
+  const feedback = getChainMetadataFeedback('loading');
+  renderChainLoadingSelect(sourceChainInput, settings.sourceChainName, feedback.placeholderText);
+  renderChainLoadingSelect(
+    destinationChainInput,
+    settings.destinationChainName,
+    feedback.placeholderText
+  );
+  updateEndpointFields();
+}
+
 function renderChainSelect(
   select: HTMLSelectElement,
   chains: ChainSummary[],
@@ -370,6 +420,7 @@ function renderChainOptions(chains: ChainSummary[]): void {
 }
 
 async function loadChainSummaries(): Promise<void> {
+  setChainMetadataState('loading');
   try {
     const data = await fetchJson(buildServiceUrl('/api/chains-summary'));
     const chains = normalizeChainSummaries(data);
@@ -379,9 +430,11 @@ async function loadChainSummaries(): Promise<void> {
 
     chainSummaries = chains;
     renderChainOptions(chains);
+    setChainMetadataState('ready');
   } catch {
     chainSummaries = FALLBACK_CHAINS;
     renderChainOptions(FALLBACK_CHAINS);
+    setChainMetadataState('fallback');
   }
 }
 
@@ -770,6 +823,11 @@ async function runLookup(settings: AppSettings): Promise<void> {
 
 form.addEventListener('submit', async (event) => {
   event.preventDefault();
+  if (lookupDisabledForChains) {
+    setChainMetadataState('loading');
+    return;
+  }
+
   const settings = readSettings();
   saveSettings(settings);
   setBusy(true);
@@ -806,7 +864,8 @@ endpointModeInput.addEventListener('change', updateEndpointFields);
 sourceChainInput.addEventListener('change', updateEndpointFields);
 destinationChainInput.addEventListener('change', updateEndpointFields);
 
-applySettings(loadSettings());
+const initialSettings = loadSettings();
+renderChainLoadingOptions(initialSettings);
+applySettings(initialSettings);
 void loadChainSummaries();
 renderHistory();
-setStatus('Ready', 'idle');

--- a/web-src/lookup.test.ts
+++ b/web-src/lookup.test.ts
@@ -11,6 +11,7 @@ import {
   buildIbcDenom,
   buildLookupUrl,
   buildSupplyByDenomPath,
+  getChainMetadataFeedback,
   getNextBalancePageKey,
   normalizeBalances,
   normalizeChainSelection,
@@ -164,6 +165,35 @@ describe('web lookup helpers', () => {
     );
 
     assert.deepEqual(normalizeChainSummaries({}), []);
+  });
+
+  it('describes chain metadata loading and fallback states for the UI', () => {
+    assert.deepEqual(getChainMetadataFeedback('loading'), {
+      statusMessage: 'Loading chains',
+      statusState: 'busy',
+      note: 'Loading chain metadata from Lazy-LB',
+      chainControlsDisabled: true,
+      lookupDisabled: true,
+      placeholderText: 'Loading chains...',
+    });
+
+    assert.deepEqual(getChainMetadataFeedback('ready'), {
+      statusMessage: 'Ready',
+      statusState: 'idle',
+      note: '',
+      chainControlsDisabled: false,
+      lookupDisabled: false,
+      placeholderText: '',
+    });
+
+    assert.deepEqual(getChainMetadataFeedback('fallback'), {
+      statusMessage: 'Limited chain list',
+      statusState: 'error',
+      note: 'Chain metadata unavailable; using limited fallback chains',
+      chainControlsDisabled: false,
+      lookupDisabled: false,
+      placeholderText: '',
+    });
   });
 
   it('resolves chain selections by name or chain ID', () => {

--- a/web-src/lookup.ts
+++ b/web-src/lookup.ts
@@ -39,6 +39,18 @@ export interface ChainSummary {
   restCount: number;
 }
 
+export type StatusState = 'idle' | 'busy' | 'ok' | 'error';
+export type ChainMetadataState = 'loading' | 'ready' | 'fallback';
+
+export interface ChainMetadataFeedback {
+  statusMessage: string;
+  statusState: StatusState;
+  note: string;
+  chainControlsDisabled: boolean;
+  lookupDisabled: boolean;
+  placeholderText: string;
+}
+
 export interface IbcLink {
   sourceChainName: string;
   sourceChainId: string;
@@ -153,6 +165,39 @@ export interface ClientStateResponse {
 }
 
 const DEFAULT_DIRECT_REST_BASE_URL = 'https://rest.cosmos.directory';
+
+export function getChainMetadataFeedback(state: ChainMetadataState): ChainMetadataFeedback {
+  if (state === 'loading') {
+    return {
+      statusMessage: 'Loading chains',
+      statusState: 'busy',
+      note: 'Loading chain metadata from Lazy-LB',
+      chainControlsDisabled: true,
+      lookupDisabled: true,
+      placeholderText: 'Loading chains...',
+    };
+  }
+
+  if (state === 'fallback') {
+    return {
+      statusMessage: 'Limited chain list',
+      statusState: 'error',
+      note: 'Chain metadata unavailable; using limited fallback chains',
+      chainControlsDisabled: false,
+      lookupDisabled: false,
+      placeholderText: '',
+    };
+  }
+
+  return {
+    statusMessage: 'Ready',
+    statusState: 'idle',
+    note: '',
+    chainControlsDisabled: false,
+    lookupDisabled: false,
+    placeholderText: '',
+  };
+}
 
 export function validateChannelId(channelId: string): void {
   if (!/^channel-\d+$/.test(channelId.trim())) {

--- a/web/index.html
+++ b/web/index.html
@@ -39,9 +39,7 @@
                 name="sourceChain"
                 required
               >
-                <option value="cosmoshub">cosmoshub cosmoshub-4</option>
-                <option value="osmosis">osmosis osmosis-1</option>
-                <option value="noble">noble noble-1</option>
+                <option value="">Loading chains...</option>
               </select>
             </label>
             <label>
@@ -51,9 +49,7 @@
                 name="destinationChain"
                 required
               >
-                <option value="osmosis">osmosis osmosis-1</option>
-                <option value="cosmoshub">cosmoshub cosmoshub-4</option>
-                <option value="noble">noble noble-1</option>
+                <option value="">Loading chains...</option>
               </select>
             </label>
             <label>
@@ -65,6 +61,9 @@
               </select>
             </label>
           </div>
+          <p id="chain-list-note" class="field-note" aria-live="polite">
+            Loading chain metadata from Lazy-LB
+          </p>
 
           <div class="field-grid secondary-grid">
             <label>

--- a/web/styles.css
+++ b/web/styles.css
@@ -209,6 +209,29 @@ select:focus {
   box-shadow: 0 0 0 2px rgba(120, 214, 111, 0.18);
 }
 
+input:disabled,
+select:disabled {
+  color: var(--muted);
+  border-color: rgba(104, 135, 101, 0.45);
+  background: rgba(9, 11, 8, 0.72);
+  cursor: wait;
+  opacity: 0.82;
+}
+
+.field-note {
+  margin: -4px 14px 14px;
+  color: var(--amber);
+  font: 0.78rem / 1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.field-note[data-state="loading"] {
+  color: var(--cyan);
+}
+
+.field-note[data-state="fallback"] {
+  color: var(--amber);
+}
+
 .wide-field {
   padding: 0 14px 14px;
 }


### PR DESCRIPTION
## Summary
- Replace the static three-chain startup fallback with disabled loading placeholders.
- Show chain metadata loading/fallback status in the existing TUI-style status area.
- Keep lookup controls disabled until chain metadata is loaded or the app explicitly enters limited fallback mode.

## Test Plan
- npm run lint
- npm test
- npm run build