### PR TITLE
Cache bust web bundle reference

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
     />
     <title>IBC Escrow Explorer</title>
     <link rel="stylesheet" href="./styles.css" />
-    <script type="module" src="./assets/app.js"></script>
+    <script type="module" src="./assets/app.js?v=chain-loading-20260628"></script>
   </head>
   <body>
     <main class="app-shell">


### PR DESCRIPTION
## Summary
- Add a version query to the frontend module URL so browsers do not keep using the immutable cached app bundle after web UI changes.

## Test Plan
- npm run lint
- npm test
- npm run build